### PR TITLE
Modify efibootorderfix to support distro changes

### DIFF
--- a/repos/system_upgrade/common/actors/efibootorderfix/finalization/actor.py
+++ b/repos/system_upgrade/common/actors/efibootorderfix/finalization/actor.py
@@ -1,17 +1,68 @@
-from leapp.actors import Actor
-from leapp.libraries.common import efi_reboot_fix
-from leapp.tags import FinalizationPhaseTag, IPUWorkflowTag
+import os
 
+from leapp.libraries.stdlib import run
+from leapp.actors import Actor
+from leapp.models import InstalledTargetKernelVersion, KernelCmdlineArg, FirmwareFacts, MountEntry
+from leapp.tags import FinalizationPhaseTag, IPUWorkflowTag
+from leapp.exceptions import StopActorExecutionError
 
 class EfiFinalizationFix(Actor):
     """
-    Adjust EFI boot entry for final reboot
+    Ensure that EFI boot order is updated, which is particularly necessary
+    when upgrading to a different OS distro. Also rebuilds grub config
+    if necessary.
     """
 
     name = 'efi_finalization_fix'
-    consumes = ()
+    consumes = (KernelCmdlineArg, InstalledTargetKernelVersion, FirmwareFacts, MountEntry)
     produces = ()
     tags = (FinalizationPhaseTag, IPUWorkflowTag)
 
     def process(self):
-        efi_reboot_fix.maybe_emit_updated_boot_entry()
+        is_system_efi = False
+        ff = next(self.consume(FirmwareFacts), None)
+
+        dirname = {
+                'AlmaLinux': 'almalinux',
+                'CentOS Linux': 'centos',
+                'CentOS Stream': 'centos',
+                'Oracle Linux Server': 'redhat',
+                'Red Hat Enterprise Linux': 'redhat',
+                'Rocky Linux': 'rocky'
+        }
+
+        with open('/etc/system-release', 'r') as sr:
+                for line in sr:
+                        if 'release' in line:
+                                distro = line.split(' release ',1)[0]
+
+        release = distro + " 8"
+        distro_dir = dirname.get(distro, 'default')
+        shim_path = '/boot/efi/EFI/' + distro_dir + '/shimx64.efi'
+        grub_cfg_path =  '/boot/efi/EFI/' + distro_dir + '/grub.cfg'
+        bootmgr_path = '\\EFI\\' + distro_dir + '\\shimx64.efi'
+
+        has_efibootmgr = os.path.exists('/sbin/efibootmgr')
+        has_shim = os.path.exists(shim_path)
+        has_grub_cfg = os.path.exists(grub_cfg_path)
+
+        if not ff:
+            raise StopActorExecutionError(
+                'Could not identify system firmware',
+                details={'details': 'Actor did not receive FirmwareFacts message.'}
+            )
+
+        for fact in self.consume(FirmwareFacts):
+            if fact.firmware == 'efi':
+                is_system_efi = True
+                break
+
+        if is_system_efi and has_shim:
+            with open('/proc/mounts', 'r') as fp:
+                for line in fp:
+                    if '/boot/efi' in line:
+                        efidev = line.split(' ',1)[0]
+            run(['/sbin/efibootmgr', '-c', '-d', efidev, '-p 1', '-l', bootmgr_path, '-L', release])
+
+            if not has_grub_cfg:
+                    run(['/sbin/grub2-mkconfig', '-o', grub_cfg_path])

--- a/repos/system_upgrade/common/actors/efibootorderfix/finalization/actor.py
+++ b/repos/system_upgrade/common/actors/efibootorderfix/finalization/actor.py
@@ -39,9 +39,9 @@ class EfiFinalizationFix(Actor):
 
         with open('/etc/system-release', 'r') as sr:
             release_line = next(line for line in sr if 'release' in line)
-            distro, release = release_line.split(' release ', 1)
+            distro = release_line.split(' release ', 1)[0]
 
-        efi_bootentry_label = distro + " " + release
+        efi_bootentry_label = distro
         distro_dir = dirname.get(distro, 'default')
         shim_filename = efi_shimname_dict.get(api.current_actor().configuration.architecture, 'shimx64.efi')
 

--- a/repos/system_upgrade/common/actors/efibootorderfix/finalization/actor.py
+++ b/repos/system_upgrade/common/actors/efibootorderfix/finalization/actor.py
@@ -59,6 +59,9 @@ class EfiFinalizationFix(Actor):
                 details={'details': 'Actor did not receive FirmwareFacts message.'}
             )
 
+        if not has_efibootmgr:
+            return
+
         for fact in self.consume(FirmwareFacts):
             if fact.firmware == 'efi':
                 is_system_efi = True


### PR DESCRIPTION
AlmaLinux/leapp-repository supports upgrades to different OS
distributions (e.g. CentOS 7 -> Rocky 8); however the
efibootorderfix (finalization) actor only assumes you are
upgrading to the same distro (e.g. Redhat 7 -> Redhat 8). This
causes first boot to fail on UEFI-enabled hardware post-upgrade.
This patch makes the EFI bootloader entry configuration more flexible
to support distro changes.

The two main functions of this patch:

1. Ensure that the EFI bootloader path is correct for the OS distribution we are upgrading to, and
2. Check to see if a `grub.cfg` exists in the new EFI path, and if not, generate one