### PR TITLE
Add Cloudlinux 7.9 to the list of supported source versions

### DIFF
--- a/repos/system_upgrade/common/actors/efibootorderfix/finalization/actor.py
+++ b/repos/system_upgrade/common/actors/efibootorderfix/finalization/actor.py
@@ -29,7 +29,8 @@ class EfiFinalizationFix(Actor):
                 'CentOS Stream': 'centos',
                 'Oracle Linux Server': 'redhat',
                 'Red Hat Enterprise Linux': 'redhat',
-                'Rocky Linux': 'rocky'
+                'Rocky Linux': 'rocky',
+                'CloudLinux': 'centos',
         }
 
         efi_shimname_dict = {

--- a/repos/system_upgrade/common/libraries/config/version.py
+++ b/repos/system_upgrade/common/libraries/config/version.py
@@ -13,7 +13,7 @@ OP_MAP = {
 
 _SUPPORTED_VERSIONS = {
     # Note: 'rhel-alt' is detected when on 'rhel' with kernel 4.x
-    '7': {'rhel': ['7.9'], 'rhel-alt': ['7.6'], 'rhel-saphana': ['7.9'], 'centos': ['7.9'], 'eurolinux': ['7.9'], 'ol': ['7.9']},
+    '7': {'rhel': ['7.9'], 'rhel-alt': ['7.6'], 'rhel-saphana': ['7.9'], 'centos': ['7.9'], 'eurolinux': ['7.9'], 'ol': ['7.9'], 'cloudlinux': ['7.9']},
     '8': {'rhel': ['8.5', '8.6'], 'centos': ['8.5'], 'almalinux': ['8.6'], 'eurolinux': ['8.6'], 'ol': ['8.6'], 'rocky': ['8.6']},
 }
 


### PR DESCRIPTION
CL 7.9 was intended to be enabled as supported in the previous series of PRs already, but wasn't - possibly due to the 0.16 merge overwriting the changes while I failed to notice.
This re-adds CL to the list of supported versions.