### PR TITLE
Remove CloudLinux-related leapp repo from el8toel9 package

### DIFF
--- a/packaging/leapp-repository.spec
+++ b/packaging/leapp-repository.spec
@@ -196,6 +196,8 @@ rm -rf %{buildroot}%{leapp_python_sitelib}/leapp/cli/commands/tests
 rm -rf %{buildroot}%{repositorydir}/system_upgrade/el8toel9
 %else
 rm -rf %{buildroot}%{repositorydir}/system_upgrade/el7toel8
+# CloudLinux migration only supports el7 to el8
+rm -rf %{buildroot}%{repositorydir}/system_upgrade/cloudlinux
 %endif
 
 # remove component/unit tests, Makefiles, ... stuff that related to testing only


### PR DESCRIPTION
The CloudLinux leapp repository depends on the el7toel8 repository, which doesn't exist in el8toel9 version of the package.
CL doesn't support migration to el9 anyway, so removing it as well in that scenario is the logical step.