### PR TITLE
Add an actor to inhibit upgrade on CloudLinux with a control panel present

### DIFF
--- a/repos/system_upgrade/cloudlinux/actors/checkrhnclienttools/actor.py
+++ b/repos/system_upgrade/cloudlinux/actors/checkrhnclienttools/actor.py
@@ -1,5 +1,6 @@
 from leapp.actors import Actor
 from leapp import reporting
+from leapp.reporting import Report
 from leapp.tags import ChecksPhaseTag, IPUWorkflowTag
 from leapp.libraries.common.cllaunch import run_on_cloudlinux
 
@@ -17,7 +18,7 @@ class CheckRhnClientToolsVersion(Actor):
 
     name = 'check_rhn_client_tools_version'
     consumes = ()
-    produces = ()
+    produces = (Report,)
     tags = (ChecksPhaseTag, IPUWorkflowTag)
 
     minimal_version = Version('2.0.2')

--- a/repos/system_upgrade/cloudlinux/actors/detectcontrolpanel/actor.py
+++ b/repos/system_upgrade/cloudlinux/actors/detectcontrolpanel/actor.py
@@ -1,0 +1,44 @@
+from leapp import reporting
+from leapp.actors import Actor
+from leapp.reporting import Report
+from leapp.tags import ChecksPhaseTag, IPUWorkflowTag
+
+from leapp.libraries.common.cllaunch import run_on_cloudlinux
+from leapp.libraries.actor.detectcontrolpanel import detect_panel, UNKNOWN_NAME
+
+
+class DetectControlPanel(Actor):
+    """
+    Check for a presence of a control panel, and inhibit the upgrade if one is found.
+    """
+
+    name = 'detect_control_panel'
+    consumes = ()
+    produces = (Report,)
+    tags = (ChecksPhaseTag, IPUWorkflowTag)
+
+    @run_on_cloudlinux
+    def process(self):
+        panel = detect_panel()
+
+        if panel:
+            summary_info = "Detected panel: {}".format(panel)
+            if panel == UNKNOWN_NAME:
+                summary_info = "Legacy custom panel script detected in CloudLinux configuration"
+
+            # Block the upgrade on any systems with a panel detected.
+            reporting.create_report([
+                reporting.Title("The upgrade process should not be run on systems with a control panel present."),
+                reporting.Summary(
+                    "Systems with a control panel present are not supported at the moment."
+                    " No control panels are currently included in the Leapp database, which"
+                    " makes loss of functionality after the upgrade extremely likely."
+                    " {}.".format(summary_info)),
+                reporting.Severity(reporting.Severity.HIGH),
+                reporting.Tags([
+                    reporting.Tags.OS_FACTS
+                ]),
+                reporting.Flags([
+                    reporting.Flags.INHIBITOR
+                ])
+                ])

--- a/repos/system_upgrade/cloudlinux/actors/detectcontrolpanel/libraries/detectcontrolpanel.py
+++ b/repos/system_upgrade/cloudlinux/actors/detectcontrolpanel/libraries/detectcontrolpanel.py
@@ -1,0 +1,68 @@
+﻿import os
+import os.path
+
+from leapp.libraries.stdlib import api
+
+
+CPANEL_NAME = 'cPanel'
+DIRECTADMIN_NAME = 'DirectAdmin'
+PLESK_NAME = 'Plesk'
+ISPMANAGER_NAME = 'ISPManager'
+INTERWORX_NAME = 'InterWorx'
+UNKNOWN_NAME = 'Unknown'
+INTEGRATED_NAME = 'Integrated'
+
+CLSYSCONFIG = '/etc/sysconfig/cloudlinux'
+
+
+def lvectl_custompanel_script():
+    """
+    Retrives custom panel script for lvectl from CL config file
+    :return: Script path or None if script filename wasn't found in config
+    """
+    config_param_name = 'CUSTOM_GETPACKAGE_SCRIPT'
+    try:
+        # Try to determine the custom script name
+        if os.path.exists(CLSYSCONFIG):
+            with open(CLSYSCONFIG, 'r') as f:
+                file_lines = f.readlines()
+            for line in file_lines:
+                line = line.strip()
+                if line.startswith(config_param_name):
+                    line_parts = line.split('=')
+                    if len(line_parts) == 2 and line_parts[0].strip() == config_param_name:
+                        script_name = line_parts[1].strip()
+                        if os.path.exists(script_name):
+                            return script_name
+    except (OSError, IOError, IndexError):
+        # Ignore errors - what's important is that the script wasn't found
+        pass
+    return None
+
+
+def detect_panel():
+    """
+    This function will try to detect control panels supported by CloudLinux
+    :return: Detected control panel name or None
+    """
+    panel_name = None
+    if os.path.isfile('/opt/cpvendor/etc/integration.ini'):
+        panel_name = INTEGRATED_NAME
+    elif os.path.isfile('/usr/local/cpanel/cpanel'):
+        panel_name = CPANEL_NAME
+    elif os.path.isfile('/usr/local/directadmin/directadmin') or\
+            os.path.isfile('/usr/local/directadmin/custombuild/build'):
+        panel_name = DIRECTADMIN_NAME
+    elif os.path.isfile('/usr/local/psa/version'):
+        panel_name = PLESK_NAME
+    # ispmanager must have:
+    # v5: /usr/local/mgr5/ directory,
+    # v4: /usr/local/ispmgr/bin/ispmgr file
+    elif os.path.isfile('/usr/local/ispmgr/bin/ispmgr') or os.path.isdir('/usr/local/mgr5'):
+        panel_name = ISPMANAGER_NAME
+    elif os.path.isdir('/usr/local/interworx'):
+        panel_name = INTERWORX_NAME
+    # Check if the CL config has a legacy custom script for a control panel
+    elif lvectl_custompanel_script():
+        panel_name = UNKNOWN_NAME
+    return panel_name


### PR DESCRIPTION
None of the control panels that can be installed with CloudLinux are present in the leapp data.
This essentially guarantees that attempting to upgrade a system with a control panel will break something.

This PR adds an actor that blocks upgrading on CloudLinux if it detects a control panel. 