### PR TITLE
Check for vendor beta repos being enabled before including beta repos in the upgrade

### DIFF
--- a/repos/system_upgrade/common/actors/scanvendorrepofiles/actor.py
+++ b/repos/system_upgrade/common/actors/scanvendorrepofiles/actor.py
@@ -1,6 +1,10 @@
 from leapp.actors import Actor
 from leapp.libraries.actor import scanvendorrepofiles
-from leapp.models import CustomTargetRepository, CustomTargetRepositoryFile, ActiveVendorList
+from leapp.models import (
+    CustomTargetRepositoryFile,
+    ActiveVendorList,
+    VendorCustomTargetRepositoryList,
+)
 from leapp.tags import FactsPhaseTag, IPUWorkflowTag
 from leapp.libraries.stdlib import api
 
@@ -12,8 +16,11 @@ class ScanVendorRepofiles(Actor):
     """
 
     name = "scan_vendor_repofiles"
-    consumes = (ActiveVendorList)
-    produces = (CustomTargetRepository, CustomTargetRepositoryFile)
+    consumes = ActiveVendorList
+    produces = (
+        CustomTargetRepositoryFile,
+        VendorCustomTargetRepositoryList,
+    )
     tags = (FactsPhaseTag, IPUWorkflowTag)
 
     def process(self):

--- a/repos/system_upgrade/common/actors/scanvendorrepofiles/libraries/scanvendorrepofiles.py
+++ b/repos/system_upgrade/common/actors/scanvendorrepofiles/libraries/scanvendorrepofiles.py
@@ -2,7 +2,11 @@ import os
 
 from leapp.libraries.common import repofileutils
 from leapp.libraries.stdlib import api
-from leapp.models import CustomTargetRepository, CustomTargetRepositoryFile, ActiveVendorList
+from leapp.models import (
+    CustomTargetRepositoryFile,
+    ActiveVendorList,
+    VendorCustomTargetRepositoryList,
+)
 
 
 VENDORS_DIR = "/etc/leapp/files/vendors.d/"
@@ -33,9 +37,7 @@ def process():
         for vendor_list in api.consume(ActiveVendorList):
             active_vendors.extend(vendor_list.data)
 
-        api.current_logger().debug(
-            "Active vendor list: {}".format(active_vendors)
-        )
+        api.current_logger().debug("Active vendor list: {}".format(active_vendors))
 
         if vendor_name not in active_vendors:
             api.current_logger().debug(
@@ -50,18 +52,10 @@ def process():
         repofile = repofileutils.parse_repofile(full_repo_path)
 
         api.produce(CustomTargetRepositoryFile(file=full_repo_path))
-        for repo in repofile.data:
-            api.current_logger().debug(
-                "Loaded repository {} from file {}".format(repo.repoid, reponame)
-            )
-            api.produce(
-                CustomTargetRepository(
-                    repoid=repo.repoid,
-                    name=repo.name,
-                    baseurl=repo.baseurl,
-                    enabled=repo.enabled,
-                )
-            )
+
+        api.produce(
+            VendorCustomTargetRepositoryList(vendor=vendor_name, repos=repofile.data)
+        )
 
     api.current_logger().info(
         "The {} directory exists, vendor repositories loaded.".format(VENDORS_DIR)

--- a/repos/system_upgrade/common/actors/scanvendorrepofiles/libraries/scanvendorrepofiles.py
+++ b/repos/system_upgrade/common/actors/scanvendorrepofiles/libraries/scanvendorrepofiles.py
@@ -3,6 +3,7 @@ import os
 from leapp.libraries.common import repofileutils
 from leapp.libraries.stdlib import api
 from leapp.models import (
+    CustomTargetRepository,
     CustomTargetRepositoryFile,
     ActiveVendorList,
     VendorCustomTargetRepositoryList,
@@ -53,8 +54,17 @@ def process():
 
         api.produce(CustomTargetRepositoryFile(file=full_repo_path))
 
+        custom_vendor_repos = [
+            CustomTargetRepository(
+                repoid=repo.repoid,
+                name=repo.name,
+                baseurl=repo.baseurl,
+                enabled=repo.enabled,
+            ) for repo in repofile.data
+        ]
+
         api.produce(
-            VendorCustomTargetRepositoryList(vendor=vendor_name, repos=repofile.data)
+            VendorCustomTargetRepositoryList(vendor=vendor_name, repos=custom_vendor_repos)
         )
 
     api.current_logger().info(

--- a/repos/system_upgrade/common/actors/setuptargetrepos/actor.py
+++ b/repos/system_upgrade/common/actors/setuptargetrepos/actor.py
@@ -9,7 +9,8 @@ from leapp.models import (
     RHUIInfo,
     SkippedRepositories,
     TargetRepositories,
-    UsedRepositories
+    UsedRepositories,
+    VendorCustomTargetRepositoryList
 )
 from leapp.tags import FactsPhaseTag, IPUWorkflowTag
 from leapp.libraries.stdlib import api
@@ -31,7 +32,8 @@ class SetupTargetRepos(Actor):
                 RepositoriesFacts,
                 RepositoriesBlacklisted,
                 RHUIInfo,
-                UsedRepositories)
+                UsedRepositories,
+                VendorCustomTargetRepositoryList)
     produces = (TargetRepositories, SkippedRepositories)
     tags = (IPUWorkflowTag, FactsPhaseTag)
 

--- a/repos/system_upgrade/common/actors/vendorreposignaturescanner/actor.py
+++ b/repos/system_upgrade/common/actors/vendorreposignaturescanner/actor.py
@@ -11,8 +11,10 @@ SIGFILE_SUFFIX = ".sigs"
 
 class VendorRepoSignatureScanner(Actor):
     """
-    Produce VendorSignatures msgs for the vendor signature files inside the
+    Produce VendorSignatures messages for the vendor signature files inside the
     <VENDORS_DIR>.
+    These messages are used to extend the list of pakcages Leapp will consider
+    signed and will attempt to upgrade.
 
     The messages are produced only if a "from" vendor repository
     listed indide its map matched one of the repositories active on the system.

--- a/repos/system_upgrade/common/actors/vendorrepositoriesmapping/libraries/vendorrepositoriesmapping.py
+++ b/repos/system_upgrade/common/actors/vendorrepositoriesmapping/libraries/vendorrepositoriesmapping.py
@@ -16,6 +16,10 @@ def read_repomap_file(repomap_file, read_repofile_func, vendor_name):
     try:
         repomap_data = RepoMapData.load_from_dict(json_data)
 
+        # What repositories associated with the vendor are expected to be present
+        # on a system with the current major version?
+        # We need to know that to know what to look for in currently enabled
+        # system repositories.
         api.produce(VendorSourceRepos(
             vendor=vendor_name,
             source_repoids=repomap_data.get_version_repoids(get_source_major_version())
@@ -23,9 +27,15 @@ def read_repomap_file(repomap_file, read_repofile_func, vendor_name):
 
         mapping = repomap_data.get_mappings(get_source_major_version(), get_target_major_version())
         valid_major_versions = [get_source_major_version(), get_target_major_version()]
+
+        # This RepositoriesMapping message is different from the one produced by the
+        # builtin actor because of the vendor field.
+        # It can be used later to distinguish the messages provided from vendors and the one
+        # from the OS upgrade data.
         api.produce(RepositoriesMapping(
             mapping=mapping,
-            repositories=repomap_data.get_repositories(valid_major_versions)
+            repositories=repomap_data.get_repositories(valid_major_versions),
+            vendor=vendor_name
         ))
     except ModelViolationError as err:
         err_message = (

--- a/repos/system_upgrade/common/models/repositoriesmap.py
+++ b/repos/system_upgrade/common/models/repositoriesmap.py
@@ -92,4 +92,4 @@ class RepositoriesMapping(Model):
 
     mapping = fields.List(fields.Model(RepoMapEntry), default=[])
     repositories = fields.List(fields.Model(PESIDRepositoryEntry), default=[])
-
+    vendor = fields.Nullable(fields.String())

--- a/repos/system_upgrade/common/models/targetrepositories.py
+++ b/repos/system_upgrade/common/models/targetrepositories.py
@@ -21,6 +21,12 @@ class CustomTargetRepository(TargetRepositoryBase):
     enabled = fields.Boolean(default=True)
 
 
+class VendorCustomTargetRepositoryList(Model):
+    topic = TransactionTopic
+    vendor = fields.String()
+    repos = fields.List(fields.Model(CustomTargetRepository))
+
+
 class TargetRepositories(Model):
     topic = TransactionTopic
     rhel_repos = fields.List(fields.Model(RHELTargetRepository))


### PR DESCRIPTION
Before this patch, any vendor beta-channel custom repositories would be unconditionally included into the upgrade process.
In fact, ga/beta/etc. marking had no bearing on custom repositories at all, and it's the primary mechanism Alma/leapp delivers its configuration.

With this patch, beta repositories for vendors will only be included into the upgrade process only if at least one of the source beta repos was present and enabled on the machine.