### PR TITLE
Copy RHN configuration files to target userspace and enable Rollout

### DIFF
--- a/repos/system_upgrade/cloudlinux/actors/scanrolloutrepositories/actor.py
+++ b/repos/system_upgrade/cloudlinux/actors/scanrolloutrepositories/actor.py
@@ -1,0 +1,28 @@
+from leapp.actors import Actor
+from leapp.libraries.actor import scanrolloutrepositories
+from leapp.models import (
+    CustomTargetRepositoryFile,
+    CustomTargetRepository,
+    UsedRepositories
+)
+from leapp.tags import FactsPhaseTag, IPUWorkflowTag
+
+
+class ScanRolloutRepositories(Actor):
+    """
+    Scan for repository files associated with the Gradual Rollout System.
+
+    Normally these repositories aren't included into the upgrade, but if one of
+    the packages on the system was installed from them, we can potentially run
+    into problems if ignoring these.
+
+    Only those repositories that had packages installed from them are included.
+    """
+
+    name = 'scan_rollout_repositories'
+    consumes = (UsedRepositories)
+    produces = (CustomTargetRepositoryFile, CustomTargetRepository)
+    tags = (FactsPhaseTag, IPUWorkflowTag)
+
+    def process(self):
+        scanrolloutrepositories.process()

--- a/repos/system_upgrade/cloudlinux/actors/scanrolloutrepositories/actor.py
+++ b/repos/system_upgrade/cloudlinux/actors/scanrolloutrepositories/actor.py
@@ -6,6 +6,7 @@ from leapp.models import (
     UsedRepositories
 )
 from leapp.tags import FactsPhaseTag, IPUWorkflowTag
+from leapp.libraries.common.cllaunch import run_on_cloudlinux
 
 
 class ScanRolloutRepositories(Actor):
@@ -24,5 +25,6 @@ class ScanRolloutRepositories(Actor):
     produces = (CustomTargetRepositoryFile, CustomTargetRepository)
     tags = (FactsPhaseTag, IPUWorkflowTag)
 
+    @run_on_cloudlinux
     def process(self):
         scanrolloutrepositories.process()

--- a/repos/system_upgrade/cloudlinux/actors/scanrolloutrepositories/libraries/scanrolloutrepositories.py
+++ b/repos/system_upgrade/cloudlinux/actors/scanrolloutrepositories/libraries/scanrolloutrepositories.py
@@ -36,11 +36,14 @@ def process():
             api.current_logger().debug("Rollout file {} has used repositories, adding".format(reponame))
 
         for repo in repofile.data:
-            api.produce(CustomTargetRepository(
-                repoid=repo.repoid,
-                name=repo.name,
-                baseurl=repo.baseurl,
-                enabled=repo.enabled,
-            ))
+            # Don't enable all the rollout repositories wholesale, some might
+            # be disabled and we want to keep that configuration.
+            if repo.enabled:
+                api.produce(CustomTargetRepository(
+                    repoid=repo.repoid,
+                    name=repo.name,
+                    baseurl=repo.baseurl,
+                    enabled=repo.enabled,
+                ))
 
         api.produce(CustomTargetRepositoryFile(file=full_repo_path))

--- a/repos/system_upgrade/cloudlinux/actors/scanrolloutrepositories/libraries/scanrolloutrepositories.py
+++ b/repos/system_upgrade/cloudlinux/actors/scanrolloutrepositories/libraries/scanrolloutrepositories.py
@@ -1,0 +1,46 @@
+import os
+
+from leapp.models import (
+    CustomTargetRepositoryFile,
+    CustomTargetRepository,
+    UsedRepositories
+)
+from leapp.libraries.stdlib import api
+from leapp.libraries.common import repofileutils
+
+REPO_DIR = '/etc/yum.repos.d'
+ROLLOUT_MARKER = 'rollout'
+CL_MARKERS = ['cloudlinux', 'imunify']
+
+
+def process():
+    used_list = []
+    for used_repos in api.consume(UsedRepositories):
+        for used_repo in used_repos.repositories:
+            used_list.append(used_repo.repository)
+
+    for reponame in os.listdir(REPO_DIR):
+        if ROLLOUT_MARKER not in reponame or not any(mark in reponame for mark in CL_MARKERS):
+            continue
+
+        api.current_logger().debug("Detected a rollout repository file: {}".format(reponame))
+
+        full_repo_path = os.path.join(REPO_DIR, reponame)
+        repofile = repofileutils.parse_repofile(full_repo_path)
+
+        # Ignore the repositories that are enabled, but have no packages installed from them.
+        if not any(repo.repoid in used_list for repo in repofile.data):
+            api.current_logger().debug("No used repositories found in {}, skipping".format(reponame))
+            continue
+        else:
+            api.current_logger().debug("Rollout file {} has used repositories, adding".format(reponame))
+
+        for repo in repofile.data:
+            api.produce(CustomTargetRepository(
+                repoid=repo.repoid,
+                name=repo.name,
+                baseurl=repo.baseurl,
+                enabled=repo.enabled,
+            ))
+
+        api.produce(CustomTargetRepositoryFile(file=full_repo_path))

--- a/repos/system_upgrade/common/actors/targetuserspacecreator/libraries/userspacegen.py
+++ b/repos/system_upgrade/common/actors/targetuserspacecreator/libraries/userspacegen.py
@@ -225,6 +225,11 @@ def _prep_repository_access(context, target_userspace):
     target_etc = os.path.join(target_userspace, 'etc')
     target_yum_repos_d = os.path.join(target_etc, 'yum.repos.d')
     backup_yum_repos_d = os.path.join(target_etc, 'yum.repos.d.backup')
+
+    # Copy RHN data independent from RHSM config
+    run(['rm', '-rf', os.path.join(target_etc, 'sysconfig/rhn')])
+    context.copytree_from('/etc/sysconfig/rhn', os.path.join(target_etc, 'sysconfig/rhn'))
+
     if not rhsm.skip_rhsm():
         run(['rm', '-rf', os.path.join(target_etc, 'pki')])
         run(['rm', '-rf', os.path.join(target_etc, 'rhsm')])

--- a/repos/system_upgrade/common/actors/targetuserspacecreator/libraries/userspacegen.py
+++ b/repos/system_upgrade/common/actors/targetuserspacecreator/libraries/userspacegen.py
@@ -227,8 +227,9 @@ def _prep_repository_access(context, target_userspace):
     backup_yum_repos_d = os.path.join(target_etc, 'yum.repos.d.backup')
 
     # Copy RHN data independent from RHSM config
-    run(['rm', '-rf', os.path.join(target_etc, 'sysconfig/rhn')])
-    context.copytree_from('/etc/sysconfig/rhn', os.path.join(target_etc, 'sysconfig/rhn'))
+    if os.path.isdir('/etc/sysconfig/rhn'):
+        run(['rm', '-rf', os.path.join(target_etc, 'sysconfig/rhn')])
+        context.copytree_from('/etc/sysconfig/rhn', os.path.join(target_etc, 'sysconfig/rhn'))
 
     if not rhsm.skip_rhsm():
         run(['rm', '-rf', os.path.join(target_etc, 'pki')])


### PR DESCRIPTION
By default, Leapp doesn't interact with the RHN system in any capacity, unlike the integrated RHSM support.
This modification doesn't have the same integration scope as the aforementioned RHSM, but it allows the user to add RHN-configured repositories to the upgrade process and have them function correctly.

Also adds a CL-only actor that makes use of the above change to enable Gradual Rollout repositories.
If you want that as a separate change, just say the word.