### PR TITLE
Introduce a PES mechanism for reinstalling identical-version packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,7 +204,9 @@ Required fields:
     - 4 - split
         - install parts of the `out_packageset` that are not present on the system
         - keep the present `out_packageset`
-        - remove packages from `in_packageset` that are no longer on the target system
+        - remove packages from `in_packageset` that are not present in `out_packageset`
+            - in case of package X being split to Y and Z, package X will be removed
+            - in case of package X being split to X and Y, package X will **not** be removed
     - 5 - merged
         - same as `split`
         - additional behaviour present, see below

--- a/README.md
+++ b/README.md
@@ -190,14 +190,15 @@ To add new rules to the list, add a new entry to the `packageinfo` array.
 Required fields:
 
 - action: what action to perform on the listed package
-- 0 - present
-- 1 - removed
-- 2 - deprecated
-- 3 - replaced
-- 4 - split
-- 5 - merged
-- 6 - moved to new repository
-- 7 - renamed
+    - 0 - present
+    - 1 - removed
+    - 2 - deprecated
+    - 3 - replaced
+    - 4 - split
+    - 5 - merged
+    - 6 - moved to new repository
+    - 7 - renamed
+    - 8 - reinstalled
 - arches: what system architectures the listed entry relates to
 - id: entry ID, must be unique
 - in_packageset: set of packages on the old system

--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ Required fields:
         - remove the `in_packageset` and install the `out_packageset` if not installed
         - if already installed, keep the `out_packageset` as-is
     - 8 - reinstalled
-        - reinstall the package during the upgrade transaction
+        - reinstall the `in_packageset` package during the upgrade transaction
         - mostly useful for packages that have the same version string between major versions, and thus won't be upgraded automatically
     - Additional notes:
         - any event except `present` is ignored if any of packages in `in_packageset` are marked for removal

--- a/README.md
+++ b/README.md
@@ -191,14 +191,36 @@ Required fields:
 
 - action: what action to perform on the listed package
     - 0 - present
+        - keep the packages in `in_packageset` to make sure the repo they're in on the target system gets enabled
+        - additional behaviour present, see below
     - 1 - removed
+        - remove all packages in `in_packageset`
     - 2 - deprecated
+        - keep the packages in `in_packageset` to make sure the repo they're in on the target system gets enabled
     - 3 - replaced
+        - remove all packages in `in_packageset`
+        - install parts of the `out_packageset` that are not present on the system
+        - keep the packages from `out_packageset` that are already installed
     - 4 - split
+        - install parts of the `out_packageset` that are not present on the system
+        - keep the present `out_packageset`
+        - remove packages from `in_packageset` that are no longer on the target system
     - 5 - merged
+        - same as `split`
+        - additional behaviour present, see below
     - 6 - moved to new repository
+        - keep the package to make sure the repo it's in on the target system gets enabled
+        - nothing is done to `in_packageset` as it always contains one package - the same as the "out" package
     - 7 - renamed
+        - remove the `in_packageset` and install the `out_packageset` if not installed
+        - if already installed, keep the `out_packageset` as-is
     - 8 - reinstalled
+        - reinstall the package during the upgrade transaction
+        - mostly useful for packages that have the same version string between major versions, and thus won't be upgraded automatically
+    - Additional notes:
+        - any event except `present` is ignored if any of packages in `in_packageset` are marked for removal
+        - any event except `merged` is ignored if any of packages in `in_packageset` are neither installed nor marked for installation
+            - for `merged` events it is sufficient to have at least one package from `in_packageset` are either installed or marked for installation
 - arches: what system architectures the listed entry relates to
 - id: entry ID, must be unique
 - in_packageset: set of packages on the old system

--- a/etc/leapp/transaction/to_reinstall
+++ b/etc/leapp/transaction/to_reinstall
@@ -1,0 +1,3 @@
+### List of packages (each on new line) to be reinstalled to the upgrade transaction
+### Useful for packages that have identical version strings but contain binary changes between major OS versions
+### Packages that aren't installed will be skipped

--- a/repos/system_upgrade/common/actors/filterrpmtransactionevents/actor.py
+++ b/repos/system_upgrade/common/actors/filterrpmtransactionevents/actor.py
@@ -47,7 +47,7 @@ class FilterRpmTransactionTasks(Actor):
         to_remove.difference_update(to_keep)
 
         # run upgrade for the rest of RH signed pkgs which we do not have rule for
-        to_upgrade = installed_pkgs - (to_install | to_remove)
+        to_upgrade = installed_pkgs - (to_install | to_remove | to_reinstall)
 
         self.produce(FilteredRpmTransactionTasks(
             local_rpms=list(local_rpms),

--- a/repos/system_upgrade/common/actors/filterrpmtransactionevents/actor.py
+++ b/repos/system_upgrade/common/actors/filterrpmtransactionevents/actor.py
@@ -32,6 +32,7 @@ class FilterRpmTransactionTasks(Actor):
         to_remove = set()
         to_keep = set()
         to_upgrade = set()
+        to_reinstall = set()
         modules_to_enable = {}
         modules_to_reset = {}
         for event in self.consume(RpmTransactionTasks, PESRpmTransactionTasks):
@@ -39,6 +40,7 @@ class FilterRpmTransactionTasks(Actor):
             to_install.update(event.to_install)
             to_remove.update(installed_pkgs.intersection(event.to_remove))
             to_keep.update(installed_pkgs.intersection(event.to_keep))
+            to_reinstall.update(installed_pkgs.intersection(event.to_reinstall))
             modules_to_enable.update({'{}:{}'.format(m.name, m.stream): m for m in event.modules_to_enable})
             modules_to_reset.update({'{}:{}'.format(m.name, m.stream): m for m in event.modules_to_reset})
 
@@ -53,5 +55,6 @@ class FilterRpmTransactionTasks(Actor):
             to_remove=list(to_remove),
             to_keep=list(to_keep),
             to_upgrade=list(to_upgrade),
+            to_reinstall=list(to_reinstall),
             modules_to_reset=list(modules_to_reset.values()),
             modules_to_enable=list(modules_to_enable.values())))

--- a/repos/system_upgrade/common/actors/peseventsscanner/libraries/peseventsscanner.py
+++ b/repos/system_upgrade/common/actors/peseventsscanner/libraries/peseventsscanner.py
@@ -59,12 +59,14 @@ class Action(IntEnum):
     MERGED = 5
     MOVED = 6
     RENAMED = 7
+    SAMEVER_UPDATED = 8
 
 
 class Task(IntEnum):
     KEEP = 0
     INSTALL = 1
     REMOVE = 2
+    REINSTALL = 3
 
     def past(self):
         return ['kept', 'installed', 'removed'][self]
@@ -240,6 +242,7 @@ def get_transaction_configuration():
         transaction_configuration.to_install.extend(tasks.to_install)
         transaction_configuration.to_remove.extend(tasks.to_remove)
         transaction_configuration.to_keep.extend(tasks.to_keep)
+        transaction_configuration.to_reinstall.extend(tasks.to_reinstall)
     return transaction_configuration
 
 
@@ -572,6 +575,13 @@ def process_events(releases, events, installed_pkgs):
                 if event.action in [Action.RENAMED, Action.REPLACED, Action.REMOVED]:
                     add_packages_to_tasks(current, event.in_pkgs, Task.REMOVE)
 
+                if event.action == Action.SAMEVER_UPDATED:
+                    # These packages have the same version string but differ in contents.
+                    # noarch packages will most likely work fine after the upgrade, but
+                    # the others may break due to library/binary incompatibilities.
+                    # This is why we mark them for reinstallation.
+                    add_packages_to_tasks(current, event.out_pkgs, Task.REINSTALL)
+
         do_not_remove = set()
         for package in current[Task.REMOVE]:
             if package in tasks[Task.KEEP]:
@@ -579,6 +589,11 @@ def process_events(releases, events, installed_pkgs):
                     '{p} :: {r} to be kept / currently removed - removing package'.format(
                         p=package[0], r=current[Task.REMOVE][package]))
                 del tasks[Task.KEEP][package]
+            if package in tasks[Task.REINSTALL]:
+                api.current_logger().warning(
+                    '{p} :: {r} to be reinstalled / currently removed - removing package'.format(
+                        p=package[0], r=current[Task.REMOVE][package]))
+                del tasks[Task.REINSTALL][package]
             elif package in tasks[Task.INSTALL]:
                 api.current_logger().warning(
                     '{p} :: {r} to be installed / currently removed - ignoring tasks'.format(
@@ -606,6 +621,11 @@ def process_events(releases, events, installed_pkgs):
                     '{p} :: {r} to be removed / currently kept - keeping package'.format(
                         p=package[0], r=current[Task.KEEP][package]))
                 del tasks[Task.REMOVE][package]
+            if package in tasks[Task.REINSTALL]:
+                api.current_logger().warning(
+                    '{p} :: {r} to be reinstalled / currently kept - keeping package'.format(
+                        p=package[0], r=current[Task.KEEP][package]))
+                del tasks[Task.REINSTALL][package]
 
         for key in Task:  # noqa: E1133; pylint: disable=not-an-iterable
             for package in current[key]:
@@ -617,7 +637,9 @@ def process_events(releases, events, installed_pkgs):
 
     map_repositories(tasks[Task.INSTALL])
     map_repositories(tasks[Task.KEEP])
+    map_repositories(tasks[Task.REINSTALL])
     filter_out_pkgs_in_blacklisted_repos(tasks[Task.INSTALL])
+    filter_out_pkgs_in_blacklisted_repos(tasks[Task.REINSTALL])
     resolve_conflicting_requests(tasks)
 
     return tasks
@@ -696,15 +718,24 @@ def resolve_conflicting_requests(tasks):
         -> without this function, sip would reside in both [Task.KEEP] and [Task.REMOVE], causing a dnf conflict
     """
     pkgs_in_conflict = set()
-    for pkg in list(tasks[Task.INSTALL].keys()) + list(tasks[Task.KEEP].keys()):
+    preserve_keys = (
+        list(tasks[Task.INSTALL].keys())
+        + list(tasks[Task.KEEP].keys())
+        + list(tasks[Task.REINSTALL].keys())
+    )
+
+    for pkg in preserve_keys:
         if pkg in tasks[Task.REMOVE]:
             pkgs_in_conflict.add(pkg)
             del tasks[Task.REMOVE][pkg]
 
     if pkgs_in_conflict:
-        api.current_logger().debug('The following packages were marked to be kept/installed and removed at the same'
-                                   ' time. Leapp will upgrade them.\n{}'.format(
-                                       '\n'.join(sorted(pkg[0] for pkg in pkgs_in_conflict))))
+        api.current_logger().debug(
+            "The following packages were marked to be kept/installed/reinstalled"
+            " and removed at the same time. Leapp will upgrade them.\n{}".format(
+                "\n".join(sorted(pkg[0] for pkg in pkgs_in_conflict))
+            )
+        )
 
 
 def get_repositories_blacklisted():
@@ -780,7 +811,7 @@ def add_output_pkgs_to_transaction_conf(transaction_configuration, events):
     message = 'The following target system packages will not be installed:\n'
 
     for event in events:
-        if event.action in (Action.SPLIT, Action.MERGED, Action.REPLACED, Action.RENAMED):
+        if event.action in (Action.SPLIT, Action.MERGED, Action.REPLACED, Action.RENAMED, Action.SAMEVER_UPDATED):
             if all([pkg.name in transaction_configuration.to_remove for pkg in event.in_pkgs]):
                 transaction_configuration.to_remove.extend(pkg.name for pkg in event.out_pkgs)
                 message += (
@@ -807,6 +838,7 @@ def filter_out_transaction_conf_pkgs(tasks, transaction_configuration):
     """
     do_not_keep = [p for p in tasks[Task.KEEP] if p[0] in transaction_configuration.to_remove]
     do_not_install = [p for p in tasks[Task.INSTALL] if p[0] in transaction_configuration.to_remove]
+    do_not_reinstall = [p for p in tasks[Task.REINSTALL] if p[0] in transaction_configuration.to_remove]
     do_not_remove = [p for p in tasks[Task.REMOVE] if p[0] in transaction_configuration.to_install
                      or p[0] in transaction_configuration.to_keep]
 
@@ -820,6 +852,12 @@ def filter_out_transaction_conf_pkgs(tasks, transaction_configuration):
         api.current_logger().debug('The following packages will not be installed because of the'
                                    ' /etc/leapp/transaction/to_remove transaction configuration file:'
                                    '\n- ' + '\n- '.join(p[0] for p in sorted(do_not_install)))
+    if do_not_reinstall:
+        for pkg in do_not_reinstall:
+            tasks[Task.REINSTALL].pop(pkg)
+        api.current_logger().debug('The following packages will not be reinstalled because of the'
+                                   ' /etc/leapp/transaction/to_remove transaction configuration file:'
+                                   '\n- ' + '\n- '.join(p[0] for p in sorted(do_not_reinstall)))
     if do_not_remove:
         for pkg in do_not_remove:
             tasks[Task.REMOVE].pop(pkg)
@@ -844,17 +882,20 @@ def produce_messages(tasks):
     # Type casting to list to be Py2&Py3 compatible as on Py3 keys() returns dict_keys(), not a list
     to_install_pkgs = sorted(tasks[Task.INSTALL].keys())
     to_remove_pkgs = sorted(tasks[Task.REMOVE].keys())
+    to_reinstall_pkgs = sorted(tasks[Task.REINSTALL].keys())
     to_enable_repos = sorted(set(tasks[Task.INSTALL].values()) | set(tasks[Task.KEEP].values()))
 
-    if to_install_pkgs or to_remove_pkgs:
+    if to_install_pkgs or to_remove_pkgs or to_reinstall_pkgs:
         enabled_modules = _get_enabled_modules()
         modules_to_enable = [Module(name=p[1][0], stream=p[1][1]) for p in to_install_pkgs if p[1]]
         modules_to_reset = enabled_modules
         to_install_pkg_names = [p[0] for p in to_install_pkgs]
         to_remove_pkg_names = [p[0] for p in to_remove_pkgs]
+        to_reinstall_pkg_names = [p[0] for p in to_reinstall_pkgs]
 
         api.produce(PESRpmTransactionTasks(to_install=to_install_pkg_names,
                                            to_remove=to_remove_pkg_names,
+                                           to_reinstall=to_reinstall_pkg_names,
                                            modules_to_enable=modules_to_enable,
                                            modules_to_reset=modules_to_reset))
 

--- a/repos/system_upgrade/common/actors/peseventsscanner/libraries/peseventsscanner.py
+++ b/repos/system_upgrade/common/actors/peseventsscanner/libraries/peseventsscanner.py
@@ -59,7 +59,7 @@ class Action(IntEnum):
     MERGED = 5
     MOVED = 6
     RENAMED = 7
-    SAMEVER_UPDATED = 8
+    REINSTALLED = 8
 
 
 class Task(IntEnum):
@@ -575,7 +575,7 @@ def process_events(releases, events, installed_pkgs):
                 if event.action in [Action.RENAMED, Action.REPLACED, Action.REMOVED]:
                     add_packages_to_tasks(current, event.in_pkgs, Task.REMOVE)
 
-                if event.action == Action.SAMEVER_UPDATED:
+                if event.action == Action.REINSTALLED:
                     # These packages have the same version string but differ in contents.
                     # noarch packages will most likely work fine after the upgrade, but
                     # the others may break due to library/binary incompatibilities.
@@ -811,7 +811,7 @@ def add_output_pkgs_to_transaction_conf(transaction_configuration, events):
     message = 'The following target system packages will not be installed:\n'
 
     for event in events:
-        if event.action in (Action.SPLIT, Action.MERGED, Action.REPLACED, Action.RENAMED, Action.SAMEVER_UPDATED):
+        if event.action in (Action.SPLIT, Action.MERGED, Action.REPLACED, Action.RENAMED, Action.REINSTALLED):
             if all([pkg.name in transaction_configuration.to_remove for pkg in event.in_pkgs]):
                 transaction_configuration.to_remove.extend(pkg.name for pkg in event.out_pkgs)
                 message += (

--- a/repos/system_upgrade/common/actors/peseventsscanner/libraries/peseventsscanner.py
+++ b/repos/system_upgrade/common/actors/peseventsscanner/libraries/peseventsscanner.py
@@ -580,7 +580,7 @@ def process_events(releases, events, installed_pkgs):
                     # noarch packages will most likely work fine after the upgrade, but
                     # the others may break due to library/binary incompatibilities.
                     # This is why we mark them for reinstallation.
-                    add_packages_to_tasks(current, event.out_pkgs, Task.REINSTALL)
+                    add_packages_to_tasks(current, event.in_pkgs, Task.REINSTALL)
 
         do_not_remove = set()
         for package in current[Task.REMOVE]:

--- a/repos/system_upgrade/common/actors/rpmtransactionconfigtaskscollector/libraries/rpmtransactionconfigtaskscollector.py
+++ b/repos/system_upgrade/common/actors/rpmtransactionconfigtaskscollector/libraries/rpmtransactionconfigtaskscollector.py
@@ -18,21 +18,37 @@ def load_tasks_file(path, logger):
     return []
 
 
+def filter_out(installed_rpm_names, to_filter, debug_msg):
+    # These are the packages that aren't installed on the system.
+    filtered_ok = [pkg for pkg in to_filter if pkg not in installed_rpm_names]
+
+    # And these ones are the ones that are.
+    filtered_out = list(set(to_filter) - set(filtered_ok))
+    if filtered_out:
+        api.current_logger().debug(
+            debug_msg +
+            '\n- ' + '\n- '.join(filtered_out)
+        )
+    # We may want to use either of the two sets.
+    return filtered_ok, filtered_out
+
+
 def load_tasks(base_dir, logger):
     # Loads configuration files to_install, to_keep, and to_remove from the given base directory
     rpms = next(api.consume(InstalledRedHatSignedRPM))
     rpm_names = [rpm.name for rpm in rpms.items]
-    to_install = load_tasks_file(os.path.join(base_dir, 'to_install'), logger)
-    # we do not want to put into rpm transaction what is already installed (it will go to "to_upgrade" bucket)
-    to_install_filtered = [pkg for pkg in to_install if pkg not in rpm_names]
 
-    filtered = set(to_install) - set(to_install_filtered)
-    if filtered:
-        api.current_logger().debug(
-            'The following packages from "to_install" file will be ignored as they are already installed:'
-            '\n- ' + '\n- '.join(filtered))
+    to_install = load_tasks_file(os.path.join(base_dir, 'to_install'), logger)
+    install_debug_msg = 'The following packages from "to_install" file will be ignored as they are already installed:'
+    # we do not want to put into rpm transaction what is already installed (it will go to "to_upgrade" bucket)
+    to_install_filtered, _ = filter_out(rpm_names, to_install, install_debug_msg)
+
+    to_reinstall = load_tasks_file(os.path.join(base_dir, 'to_reinstall'), logger)
+    reinstall_debug_msg = 'The following packages from "to_reinstall" file will be ignored as they are not installed:'
+    _, to_reinstall_filtered = filter_out(rpm_names, to_reinstall, reinstall_debug_msg)
 
     return RpmTransactionTasks(
         to_install=to_install_filtered,
+        to_reinstall=to_reinstall_filtered,
         to_keep=load_tasks_file(os.path.join(base_dir, 'to_keep'), logger),
         to_remove=load_tasks_file(os.path.join(base_dir, 'to_remove'), logger))

--- a/repos/system_upgrade/common/files/rhel_upgrade.py
+++ b/repos/system_upgrade/common/files/rhel_upgrade.py
@@ -171,6 +171,7 @@ class RhelUpgradeCommand(dnf.cli.Command):
         to_install = self.plugin_data['pkgs_info']['to_install']
         to_remove = self.plugin_data['pkgs_info']['to_remove']
         to_upgrade = self.plugin_data['pkgs_info']['to_upgrade']
+        to_reinstall = self.plugin_data['pkgs_info']['to_reinstall']
 
         # Modules to enable
         self._process_entities(entities=[modules_to_enable], op=module_base.enable, entity_name='Module stream')
@@ -181,6 +182,8 @@ class RhelUpgradeCommand(dnf.cli.Command):
         self._process_entities(entities=to_install, op=self.base.install, entity_name='Package')
         # Packages to be upgraded
         self._process_entities(entities=to_upgrade, op=self.base.upgrade, entity_name='Package')
+        # Packages to be reinstalled
+        self._process_entities(entities=to_reinstall, op=self.base.reinstall, entity_name='Package')
 
         self.base.distro_sync()
 

--- a/repos/system_upgrade/common/libraries/dnfplugin.py
+++ b/repos/system_upgrade/common/libraries/dnfplugin.py
@@ -87,6 +87,7 @@ def build_plugin_data(target_repoids, debug, test, tasks, on_aws):
             'to_install': tasks.to_install,
             'to_remove': tasks.to_remove,
             'to_upgrade': tasks.to_upgrade,
+            'to_reinstall': tasks.to_reinstall,
             'modules_to_enable': ['{}:{}'.format(m.name, m.stream) for m in tasks.modules_to_enable],
         },
         'dnf_conf': {

--- a/repos/system_upgrade/common/models/rpmtransactiontasks.py
+++ b/repos/system_upgrade/common/models/rpmtransactiontasks.py
@@ -10,6 +10,7 @@ class RpmTransactionTasks(Model):
     to_keep = fields.List(fields.String(), default=[])
     to_remove = fields.List(fields.String(), default=[])
     to_upgrade = fields.List(fields.String(), default=[])
+    to_reinstall = fields.List(fields.String(), default=[])
     modules_to_enable = fields.List(fields.Model(Module), default=[])
     modules_to_reset = fields.List(fields.Model(Module), default=[])
 


### PR DESCRIPTION
Normally Leapp will not attempt to upgrade packages from target repositories that have an identical version string to the package to-be-upgraded. However, in some cases, new packages may have an identical version string but differ in contents.
The prime example is a package whose library dependencies/binaries have changed between major OS versions, but whose version string doesn't reflect that change (e.g. no "*.el7.*" to "*.el8.*" version string component is present).
Due to the version string, Leapp will keep the package as is, which may cause issues on the post-upgrade system.

This patch introduces a new type of PES action that will mark the package for reinstallation in the main DNF transaction.