### PR TITLE
Check local GPG keys for existence

### DIFF
--- a/repos/system_upgrade/common/actors/scancustomrepofile/actor.py
+++ b/repos/system_upgrade/common/actors/scancustomrepofile/actor.py
@@ -3,6 +3,7 @@ from leapp.libraries.actor import scancustomrepofile
 from leapp.models import (
     CustomTargetRepository,
     CustomTargetRepositoryFile,
+    Report
 )
 from leapp.tags import FactsPhaseTag, IPUWorkflowTag
 
@@ -23,7 +24,7 @@ class ScanCustomRepofile(Actor):
 
     name = "scan_custom_repofile"
     consumes = ()
-    produces = (CustomTargetRepository, CustomTargetRepositoryFile)
+    produces = (CustomTargetRepository, CustomTargetRepositoryFile, Report)
     tags = (FactsPhaseTag, IPUWorkflowTag)
 
     def process(self):

--- a/repos/system_upgrade/common/actors/scancustomrepofile/libraries/scancustomrepofile.py
+++ b/repos/system_upgrade/common/actors/scancustomrepofile/libraries/scancustomrepofile.py
@@ -4,6 +4,8 @@ from leapp.libraries.common import repofileutils
 from leapp.libraries.stdlib import api
 from leapp.models import CustomTargetRepository, CustomTargetRepositoryFile
 
+from leapp.reporting import create_report
+from leapp import reporting
 
 CUSTOM_REPO_PATH = "/etc/leapp/files/leapp_upgrade_repositories.repo"
 
@@ -28,17 +30,44 @@ def process():
             "The {} file exists, but is empty. Nothing to do.".format(CUSTOM_REPO_PATH)
         )
         return
-    api.produce(CustomTargetRepositoryFile(file=CUSTOM_REPO_PATH))
 
-    for repo in repofile.data:
-        api.produce(
-            CustomTargetRepository(
-                repoid=repo.repoid,
-                name=repo.name,
-                baseurl=repo.baseurl,
-                enabled=repo.enabled,
+    repos_with_missing_keys, missing_gpgkeys = repofileutils.check_gpgkey_existence(repofile.data)
+    if repos_with_missing_keys:
+        repos_related = [reporting.RelatedResource('repository', str(r)) for r in repos_with_missing_keys]
+        gpgkeys_related = [reporting.RelatedResource('file', str(r)) for r in missing_gpgkeys]
+        create_report([
+            reporting.Title('GPG key for one or more custom target repositories is missing'),
+            reporting.Summary(
+                    'Some of the GPG keys for repositories listed in the custom repository '
+                    'file weren\'t found in the system. '
+                    'If the upgrade proceeds as-is, this will cause issues with retreiving packages '
+                    'from said repositories. '
+                    'Check the list of missing keys and ensure all of them are present on the system '
+                    'before restarting the upgrade process.'
+                ),
+            reporting.Summary(),
+            reporting.Severity(reporting.Severity.HIGH),
+            reporting.Tags([
+                    reporting.Tags.FILESYSTEM,
+                    reporting.Tags.REPOSITORY,
+                    reporting.Tags.SECURITY
+            ]),
+            reporting.Remediation(hint='Add the missing keys to the system before continuing.'),
+            reporting.Flags([reporting.Flags.INHIBITOR]),
+            reporting.RelatedResource('file', '/etc/leapp/leapp_upgrade_repositories.repo')
+        ] + gpgkeys_related + repos_related)
+
+    else:
+        for repo in repofile.data:
+            api.produce(
+                CustomTargetRepository(
+                    repoid=repo.repoid,
+                    name=repo.name,
+                    baseurl=repo.baseurl,
+                    enabled=repo.enabled,
+                )
             )
+        api.produce(CustomTargetRepositoryFile(file=CUSTOM_REPO_PATH))
+        api.current_logger().info(
+            "The {} file exists, custom repositories loaded.".format(CUSTOM_REPO_PATH)
         )
-    api.current_logger().info(
-        "The {} file exists, custom repositories loaded.".format(CUSTOM_REPO_PATH)
-    )

--- a/repos/system_upgrade/common/actors/scancustomrepofile/libraries/scancustomrepofile.py
+++ b/repos/system_upgrade/common/actors/scancustomrepofile/libraries/scancustomrepofile.py
@@ -45,7 +45,6 @@ def process():
                     'Check the list of missing keys and ensure all of them are present on the system '
                     'before restarting the upgrade process.'
                 ),
-            reporting.Summary(),
             reporting.Severity(reporting.Severity.HIGH),
             reporting.Tags([
                     reporting.Tags.FILESYSTEM,

--- a/repos/system_upgrade/common/actors/scanvendorrepofiles/actor.py
+++ b/repos/system_upgrade/common/actors/scanvendorrepofiles/actor.py
@@ -4,6 +4,7 @@ from leapp.models import (
     CustomTargetRepositoryFile,
     ActiveVendorList,
     VendorCustomTargetRepositoryList,
+    Report
 )
 from leapp.tags import FactsPhaseTag, IPUWorkflowTag
 from leapp.libraries.stdlib import api
@@ -20,6 +21,7 @@ class ScanVendorRepofiles(Actor):
     produces = (
         CustomTargetRepositoryFile,
         VendorCustomTargetRepositoryList,
+        Report
     )
     tags = (FactsPhaseTag, IPUWorkflowTag)
 

--- a/repos/system_upgrade/common/actors/scanvendorrepofiles/libraries/scanvendorrepofiles.py
+++ b/repos/system_upgrade/common/actors/scanvendorrepofiles/libraries/scanvendorrepofiles.py
@@ -8,7 +8,8 @@ from leapp.models import (
     ActiveVendorList,
     VendorCustomTargetRepositoryList,
 )
-
+from leapp.reporting import create_report
+from leapp import reporting
 
 VENDORS_DIR = "/etc/leapp/files/vendors.d/"
 REPOFILE_SUFFIX = ".repo"
@@ -52,20 +53,47 @@ def process():
         full_repo_path = os.path.join(VENDORS_DIR, reponame)
         repofile = repofileutils.parse_repofile(full_repo_path)
 
-        api.produce(CustomTargetRepositoryFile(file=full_repo_path))
+        repos_with_missing_keys, missing_gpgkeys = repofileutils.check_gpgkey_existence(repofile.data)
 
-        custom_vendor_repos = [
-            CustomTargetRepository(
-                repoid=repo.repoid,
-                name=repo.name,
-                baseurl=repo.baseurl,
-                enabled=repo.enabled,
-            ) for repo in repofile.data
-        ]
+        if repos_with_missing_keys:
+            repos_related = [reporting.RelatedResource('repository', str(r)) for r in repos_with_missing_keys]
+            gpgkeys_related = [reporting.RelatedResource('file', str(r)) for r in missing_gpgkeys]
+            create_report([
+                reporting.Title('GPG key for one or more vendor target repositories is missing'),
+                reporting.Summary(
+                        'Some of the GPG keys for repositories listed in the vendor repository '
+                        'file {} weren\'t found in the system. '
+                        'If the upgrade proceeds as-is, this will cause issues with retreiving packages '
+                        'from said repositories. '
+                        'Check the list of missing keys and ensure all of them are present on the system '
+                        'before restarting the upgrade process.'.format(reponame)
+                    ),
+                reporting.Summary(),
+                reporting.Severity(reporting.Severity.HIGH),
+                reporting.Tags([
+                        reporting.Tags.FILESYSTEM,
+                        reporting.Tags.REPOSITORY,
+                        reporting.Tags.SECURITY
+                ]),
+                reporting.Remediation(hint='Add the missing keys to the system before continuing.'),
+                reporting.Flags([reporting.Flags.INHIBITOR]),
+                reporting.RelatedResource('file', full_repo_path)
+            ] + gpgkeys_related + repos_related)
 
-        api.produce(
-            VendorCustomTargetRepositoryList(vendor=vendor_name, repos=custom_vendor_repos)
-        )
+        else:
+            custom_vendor_repos = [
+                CustomTargetRepository(
+                    repoid=repo.repoid,
+                    name=repo.name,
+                    baseurl=repo.baseurl,
+                    enabled=repo.enabled,
+                ) for repo in repofile.data
+            ]
+            api.produce(CustomTargetRepositoryFile(file=full_repo_path))
+
+            api.produce(
+                VendorCustomTargetRepositoryList(vendor=vendor_name, repos=custom_vendor_repos)
+            )
 
     api.current_logger().info(
         "The {} directory exists, vendor repositories loaded.".format(VENDORS_DIR)

--- a/repos/system_upgrade/common/actors/scanvendorrepofiles/libraries/scanvendorrepofiles.py
+++ b/repos/system_upgrade/common/actors/scanvendorrepofiles/libraries/scanvendorrepofiles.py
@@ -68,7 +68,6 @@ def process():
                         'Check the list of missing keys and ensure all of them are present on the system '
                         'before restarting the upgrade process.'.format(reponame)
                     ),
-                reporting.Summary(),
                 reporting.Severity(reporting.Severity.HIGH),
                 reporting.Tags([
                         reporting.Tags.FILESYSTEM,

--- a/repos/system_upgrade/common/libraries/repofileutils.py
+++ b/repos/system_upgrade/common/libraries/repofileutils.py
@@ -1,5 +1,6 @@
-import json
 import os
+import os.path
+import json
 
 from leapp.libraries.common import mounting, utils
 from leapp.libraries.stdlib import api
@@ -104,3 +105,22 @@ def get_duplicate_repositories(repofiles):
     rf_repos = {repofile.file: [repo.repoid for repo in repofile.data] for repofile in repofiles}
     repos = _invert_dict(rf_repos)
     return {repo: set(rfiles) for repo, rfiles in repos.items() if len(set(rfiles)) > 1}
+
+
+def check_gpgkey_existence(repodata):
+    file_prefix = 'file:/'
+
+    repos_with_missing_keys = []
+    missing_keys = []
+
+    for repo in repodata:
+        repo_addfields = json.loads(repo.additional_fields)
+        if repo_addfields['gpgkey']:
+            repo_gpgkey = repo_addfields['gpgkey']
+            if file_prefix in repo_gpgkey:
+                gpgkey_path = repo_gpgkey.split(file_prefix)[1]
+                if not os.path.isfile(gpgkey_path):
+                    repos_with_missing_keys.append(repo)
+                    missing_keys.append(gpgkey_path)
+
+    return repos_with_missing_keys, missing_keys


### PR DESCRIPTION
GPG keys for custom/vendor Leapp repositories are not guaranteed to be present on the system and are not checked in any way.

That is especially problematic if GPG keys for repositories are different between the target/source systems. EPEL is an example: EPEL7 and EPEL8 repositories have different GPG keys, so a source system with EPEL 7 is all but guaranteed to not have an EPEL 8 GPG key without extra actions from the user.

This patch introduces checking GPG keys (whose paths point to the local filesystem) for existence before starting the DNF download phase.
Vendor repo GPG keys are checked as well, but only for active vendors (that is, those that have at least one source repository present and active on the source system).