### PR TITLE
Whitelist cPanel packages for the upgrade by name

### DIFF
--- a/repos/system_upgrade/common/actors/redhatsignedrpmscanner/actor.py
+++ b/repos/system_upgrade/common/actors/redhatsignedrpmscanner/actor.py
@@ -92,6 +92,21 @@ class VendorSignedRpmScanner(Actor):
             """Whitelist the katello package."""
             return pkg.name.startswith("katello-ca-consumer")
 
+        def has_cpanel_prefix(pkg):
+            """
+            Whitelist the cPanel packages.
+            A side effect of the cPanel's deployment method is that its packages both have no
+            PGP signature and aren't associated with any package repository.
+            They do, however, have a specific naming scheme that can be used to include them into
+            the upgrade process.
+            """
+
+            # NOTE: if another case like this and the above katello occurs, consider adding a
+            # mechanism (a third-party extension) to do this in a way that allows extending it to
+            # other configurations.
+            # A separate file for the "vendors.d" folder with package name wildcards?
+            return pkg.name.startswith("cpanel-")
+
         def is_azure_pkg(pkg):
             """Whitelist Azure config package."""
             upg_path = rhui.get_upg_path()
@@ -109,6 +124,7 @@ class VendorSignedRpmScanner(Actor):
                         has_vendorsig(pkg),
                         is_gpg_pubkey(pkg),
                         has_katello_prefix(pkg),
+                        has_cpanel_prefix(pkg),
                         is_azure_pkg(pkg),
                     ]
                 ):


### PR DESCRIPTION
Using the same principle the already existing `katello` whitelist does, permit cPanel packages to be included into the upgrade transaction.
It can't be done normally (through the third-party extension) due to them not having PGP signatures.

If a case like this occurs again in the future, adding third-party extension functionality to whitelist packages by name (wildcards, etc.) will be worth considering.