### PR TITLE
Implement an actor to modify yum vairables post-upgrade

### DIFF
--- a/repos/system_upgrade/el7toel8/actors/updateyumvars/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/updateyumvars/actor.py
@@ -1,0 +1,18 @@
+from leapp.actors import Actor
+from leapp.libraries.actor import updateyumvars
+from leapp.tags import ThirdPartyApplicationsPhaseTag, IPUWorkflowTag
+
+
+class UpdateYumVars(Actor):
+    """
+    Update the files corresponding to the current major
+    OS version in the /etc/yum/vars folder.
+    """
+
+    name = 'update_yum_vars'
+    consumes = ()
+    produces = ()
+    tags = (ThirdPartyApplicationsPhaseTag, IPUWorkflowTag)
+
+    def process(self):
+        updateyumvars.vars_update()

--- a/repos/system_upgrade/el7toel8/actors/updateyumvars/libraries/updateyumvars.py
+++ b/repos/system_upgrade/el7toel8/actors/updateyumvars/libraries/updateyumvars.py
@@ -1,0 +1,23 @@
+import os
+
+from leapp.libraries.stdlib import api
+
+VAR_FOLDER = "/etc/yum/vars"
+
+
+def vars_update():
+    """ Iterate through and modify the variables. """
+    if not os.path.isdir(VAR_FOLDER):
+        api.current_logger().debug(
+            "The {} directory doesn't exist. Nothing to do.".format(VAR_FOLDER)
+        )
+        return
+
+    for varfile_name in os.listdir(VAR_FOLDER):
+        # cp_centos_major_version contains the current OS' major version.
+        if varfile_name == 'cp_centos_major_version':
+            varfile_path = os.path.join(VAR_FOLDER, varfile_name)
+
+            with open(varfile_path, 'w') as varfile:
+                # Overwrite the value from outdated "7".
+                varfile.write('8')


### PR DESCRIPTION
Built-in variables like $releasever are not the only ones package repos and their URLs can use.

For example, cPanel repos use the variable `cp_centos_major_version`, which is contained in /etc/yum/vars as a file.

It’s not updated automatically and will keep its old value of 7 if nothing is done. This PR introduces a custom actor that modifies the variable files during the upgrade process.

At the moment, only `cp_centos_major_version` is modified, but the process is easily extendable.