### PR TITLE
Add a hint to error message when mapping is empty

### DIFF
--- a/repos/system_upgrade/common/actors/vendorrepositoriesmapping/libraries/vendorrepositoriesmapping.py
+++ b/repos/system_upgrade/common/actors/vendorrepositoriesmapping/libraries/vendorrepositoriesmapping.py
@@ -29,7 +29,8 @@ def read_repomap_file(repomap_file, read_repofile_func, vendor_name):
 
         api.produce(RepositoriesMapping(
             mapping=mapping,
-            repositories=repomap_data.get_repositories(valid_major_versions)
+            repositories=repomap_data.get_repositories(valid_major_versions),
+            vendor=vendor_name
         ))
     except ModelViolationError as err:
         err_message = (

--- a/repos/system_upgrade/common/actors/vendorrepositoriesmapping/libraries/vendorrepositoriesmapping.py
+++ b/repos/system_upgrade/common/actors/vendorrepositoriesmapping/libraries/vendorrepositoriesmapping.py
@@ -16,32 +16,27 @@ def read_repomap_file(repomap_file, read_repofile_func, vendor_name):
     try:
         repomap_data = RepoMapData.load_from_dict(json_data)
 
-        # What repositories associated with the vendor are expected to be present
-        # on a system with the current major version?
-        # We need to know that to know what to look for in currently enabled
-        # system repositories.
+        source_major = get_source_major_version()
+        target_major = get_target_major_version()
+
         api.produce(VendorSourceRepos(
             vendor=vendor_name,
-            source_repoids=repomap_data.get_version_repoids(get_source_major_version())
+            source_repoids=repomap_data.get_version_repoids(source_major)
         ))
 
-        mapping = repomap_data.get_mappings(get_source_major_version(), get_target_major_version())
-        valid_major_versions = [get_source_major_version(), get_target_major_version()]
+        mapping = repomap_data.get_mappings(source_major, target_major)
+        valid_major_versions = [source_major, target_major]
 
-        # This RepositoriesMapping message is different from the one produced by the
-        # builtin actor because of the vendor field.
-        # It can be used later to distinguish the messages provided from vendors and the one
-        # from the OS upgrade data.
         api.produce(RepositoriesMapping(
             mapping=mapping,
-            repositories=repomap_data.get_repositories(valid_major_versions),
-            vendor=vendor_name
+            repositories=repomap_data.get_repositories(valid_major_versions)
         ))
     except ModelViolationError as err:
         err_message = (
             'The repository mapping file is invalid: '
-            'the JSON does not match required schema (wrong field type/value): {}'
-            .format(err)
+            'the JSON does not match required schema (wrong field type/value): {}. '
+            'Ensure that the current upgrade path is correct and is present in the mappings: {} -> {}'
+            .format(err, source_major, target_major)
         )
         inhibit_upgrade(err_message)
     except KeyError as err:


### PR DESCRIPTION
If an upgrade stops halfway through, sometimes the system may start considering itself as the upgraded version, with the corresponding values in os-release.
In that case, restarting the process may yield an error message when Leapp tries to look up a mapping for the new upgrade but doesn't find one.

For example, a system configuration that only supports 7 -> 8 conversion will error out of an attempted 8 -> 9 conversion.
The underlying reasons for that behaviour I'm not yet too sure about, but an expanded error message will help with debugging in the meantime.