### PR TITLE
Unblock the CL+cPanel upgrade path

### DIFF
--- a/repos/system_upgrade/cloudlinux/actors/detectcontrolpanel/actor.py
+++ b/repos/system_upgrade/cloudlinux/actors/detectcontrolpanel/actor.py
@@ -4,15 +4,19 @@ from leapp.reporting import Report
 from leapp.tags import ChecksPhaseTag, IPUWorkflowTag
 
 from leapp.libraries.common.cllaunch import run_on_cloudlinux
-from leapp.libraries.actor.detectcontrolpanel import detect_panel, UNKNOWN_NAME
+from leapp.libraries.actor.detectcontrolpanel import (
+    detect_panel,
+    UNKNOWN_NAME,
+    CPANEL_NAME,
+)
 
 
 class DetectControlPanel(Actor):
     """
-    Check for a presence of a control panel, and inhibit the upgrade if one is found.
+    Check for a presence of a control panel, and inhibit the upgrade if an unsupported one is found.
     """
 
-    name = 'detect_control_panel'
+    name = "detect_control_panel"
     consumes = ()
     produces = (Report,)
     tags = (ChecksPhaseTag, IPUWorkflowTag)
@@ -21,24 +25,29 @@ class DetectControlPanel(Actor):
     def process(self):
         panel = detect_panel()
 
-        if panel:
+        if panel == CPANEL_NAME:
+            self.log.debug('cPanel detected, upgrade proceeding')
+        elif panel:
             summary_info = "Detected panel: {}".format(panel)
             if panel == UNKNOWN_NAME:
-                summary_info = "Legacy custom panel script detected in CloudLinux configuration"
+                summary_info = (
+                    "Legacy custom panel script detected in CloudLinux configuration"
+                )
 
             # Block the upgrade on any systems with a panel detected.
-            reporting.create_report([
-                reporting.Title("The upgrade process should not be run on systems with a control panel present."),
-                reporting.Summary(
-                    "Systems with a control panel present are not supported at the moment."
-                    " No control panels are currently included in the Leapp database, which"
-                    " makes loss of functionality after the upgrade extremely likely."
-                    " {}.".format(summary_info)),
-                reporting.Severity(reporting.Severity.HIGH),
-                reporting.Tags([
-                    reporting.Tags.OS_FACTS
-                ]),
-                reporting.Flags([
-                    reporting.Flags.INHIBITOR
-                ])
-                ])
+            reporting.create_report(
+                [
+                    reporting.Title(
+                        "The upgrade process should not be run on systems with a control panel present."
+                    ),
+                    reporting.Summary(
+                        "Systems with a control panel present are not supported at the moment."
+                        " No control panels are currently included in the Leapp database, which"
+                        " makes loss of functionality after the upgrade extremely likely."
+                        " {}.".format(summary_info)
+                    ),
+                    reporting.Severity(reporting.Severity.HIGH),
+                    reporting.Tags([reporting.Tags.OS_FACTS]),
+                    reporting.Flags([reporting.Flags.INHIBITOR]),
+                ]
+            )


### PR DESCRIPTION
Once the upgrade of CL7 with cPanel becomes possible, it should no longer be inhibited during checks.