### PR TITLE
Add rpmnew CloudLinux repository config file replacement post-upgrade

### DIFF
--- a/repos/system_upgrade/cloudlinux/actors/replacerpmnewconfigs/actor.py
+++ b/repos/system_upgrade/cloudlinux/actors/replacerpmnewconfigs/actor.py
@@ -1,0 +1,54 @@
+import os
+from leapp.actors import Actor
+from leapp.tags import FirstBootPhaseTag, IPUWorkflowTag
+from leapp import reporting
+from leapp.libraries.common.cllaunch import run_on_cloudlinux
+
+REPO_DIR = '/etc/yum.repos.d'
+CL_MARKERS = ['cloudlinux', 'imunify']
+RPMNEW = '.rpmnew'
+LEAPP_SUFFIX = '.leapp-backup'
+
+
+class ReplaceRpmnewConfigs(Actor):
+    """
+    No documentation has been provided for the replace_rpmnew_configs actor.
+    """
+
+    original = '/etc/sysconfig/rhn/up2date'
+
+    name = 'replace_rpmnew_configs'
+    consumes = ()
+    produces = ()
+    tags = (FirstBootPhaseTag, IPUWorkflowTag)
+
+    @run_on_cloudlinux
+    def process(self):
+        renamed_repofiles = []
+
+        for reponame in os.listdir(REPO_DIR):
+            if any(mark in reponame for mark in CL_MARKERS) and RPMNEW in reponame:
+                base_reponame = reponame[:-7]
+                base_path = os.path.join(REPO_DIR, base_reponame)
+                new_file_path = os.path.join(REPO_DIR, reponame)
+                backup_path = os.path.join(REPO_DIR, base_reponame + LEAPP_SUFFIX)
+
+                os.rename(base_path, backup_path)
+                os.rename(new_file_path, base_path)
+                renamed_repofiles.append(base_reponame)
+
+        if renamed_repofiles:
+            replaced_string = '\n'.join(['- {}'.format(repofile_name) for repofile_name in renamed_repofiles])
+            reporting.create_report([
+                reporting.Title('CloudLinux repository config files replaced by updated versions'),
+                reporting.Summary(
+                    'One or more RPM repository configuration files related to CloudLinux '
+                    'have been replaced with new versions provided by the upgraded packages. '
+                    'Any manual modifications to these files have been overriden by this process. '
+                    'Old versions of files were backed up to files with a naming pattern '
+                    '<repository_file_name>.leapp-backup. '
+                    'Replaced repository files: \n{}'.format(replaced_string)
+                ),
+                reporting.Severity(reporting.Severity.MEDIUM),
+                reporting.Tags([reporting.Tags.UPGRADE_PROCESS])
+            ])

--- a/repos/system_upgrade/cloudlinux/actors/replacerpmnewconfigs/actor.py
+++ b/repos/system_upgrade/cloudlinux/actors/replacerpmnewconfigs/actor.py
@@ -1,5 +1,7 @@
+from __future__ import print_function
 import os
 import fileinput
+
 from leapp.actors import Actor
 from leapp.tags import FirstBootPhaseTag, IPUWorkflowTag
 from leapp import reporting

--- a/repos/system_upgrade/cloudlinux/actors/replacerpmnewconfigs/actor.py
+++ b/repos/system_upgrade/cloudlinux/actors/replacerpmnewconfigs/actor.py
@@ -42,7 +42,7 @@ class ReplaceRpmnewConfigs(Actor):
                 repoconfig = []
                 with open(reponame) as o:
                     for line in o.readlines():
-                        if 'enabled' in line:
+                        if line.startswith('enabled'):
                             line = 'enabled = 0\n'
                         repoconfig.append(line)
                 with open(reponame, 'w') as f:

--- a/repos/system_upgrade/cloudlinux/actors/replacerpmnewconfigs/actor.py
+++ b/repos/system_upgrade/cloudlinux/actors/replacerpmnewconfigs/actor.py
@@ -10,7 +10,7 @@ from leapp.libraries.common.cllaunch import run_on_cloudlinux
 REPO_DIR = '/etc/yum.repos.d'
 CL_MARKERS = ['cloudlinux', 'imunify']
 RPMNEW = '.rpmnew'
-LEAPP_SUFFIX = '.leapp-backup'
+LEAPP_BACKUP_SUFFIX = '.leapp-backup'
 
 
 class ReplaceRpmnewConfigs(Actor):
@@ -32,14 +32,14 @@ class ReplaceRpmnewConfigs(Actor):
                 base_reponame = reponame[:-7]
                 base_path = os.path.join(REPO_DIR, base_reponame)
                 new_file_path = os.path.join(REPO_DIR, reponame)
-                backup_path = os.path.join(REPO_DIR, base_reponame + LEAPP_SUFFIX)
+                backup_path = os.path.join(REPO_DIR, base_reponame + LEAPP_BACKUP_SUFFIX)
 
                 os.rename(base_path, backup_path)
                 os.rename(new_file_path, base_path)
                 renamed_repofiles.append(base_reponame)
 
         for reponame in os.listdir(REPO_DIR):
-            if LEAPP_SUFFIX in reponame:
+            if LEAPP_BACKUP_SUFFIX in reponame:
                 repofile_path = os.path.join(REPO_DIR, reponame)
                 for line in fileinput.input(repofile_path, inplace=True):
                     if line.startswith('enabled'):

--- a/repos/system_upgrade/cloudlinux/actors/replacerpmnewconfigs/actor.py
+++ b/repos/system_upgrade/cloudlinux/actors/replacerpmnewconfigs/actor.py
@@ -37,6 +37,17 @@ class ReplaceRpmnewConfigs(Actor):
                 os.rename(new_file_path, base_path)
                 renamed_repofiles.append(base_reponame)
 
+        for reponame in os.listdir(REPO_DIR):
+            if LEAPP_SUFFIX in reponame:
+                repoconfig = []
+                with open(reponame) as o:
+                    for line in o.readlines():
+                        if 'enabled' in line:
+                            line = 'enabled = 0\n'
+                        repoconfig.append(line)
+                with open(reponame, 'w') as f:
+                    f.writelines(repoconfig)
+
         if renamed_repofiles:
             replaced_string = '\n'.join(['- {}'.format(repofile_name) for repofile_name in renamed_repofiles])
             reporting.create_report([

--- a/repos/system_upgrade/cloudlinux/actors/replacerpmnewconfigs/actor.py
+++ b/repos/system_upgrade/cloudlinux/actors/replacerpmnewconfigs/actor.py
@@ -12,7 +12,7 @@ LEAPP_SUFFIX = '.leapp-backup'
 
 class ReplaceRpmnewConfigs(Actor):
     """
-    No documentation has been provided for the replace_rpmnew_configs actor.
+    Replace CloudLinux-related repository config .rpmnew files.
     """
 
     original = '/etc/sysconfig/rhn/up2date'

--- a/repos/system_upgrade/cloudlinux/actors/replacerpmnewconfigs/actor.py
+++ b/repos/system_upgrade/cloudlinux/actors/replacerpmnewconfigs/actor.py
@@ -43,9 +43,9 @@ class ReplaceRpmnewConfigs(Actor):
                 repofile_path = os.path.join(REPO_DIR, reponame)
                 for line in fileinput.input(repofile_path, inplace=True):
                     if line.startswith('enabled'):
-                        print("enabled = 0\n")
+                        print("enabled = 0")
                     else:
-                        print(line)
+                        print(line, end='')
 
         if renamed_repofiles:
             replaced_string = '\n'.join(['- {}'.format(repofile_name) for repofile_name in renamed_repofiles])

--- a/repos/system_upgrade/cloudlinux/actors/replacerpmnewconfigs/actor.py
+++ b/repos/system_upgrade/cloudlinux/actors/replacerpmnewconfigs/actor.py
@@ -1,4 +1,5 @@
 import os
+import fileinput
 from leapp.actors import Actor
 from leapp.tags import FirstBootPhaseTag, IPUWorkflowTag
 from leapp import reporting
@@ -14,8 +15,6 @@ class ReplaceRpmnewConfigs(Actor):
     """
     Replace CloudLinux-related repository config .rpmnew files.
     """
-
-    original = '/etc/sysconfig/rhn/up2date'
 
     name = 'replace_rpmnew_configs'
     consumes = ()
@@ -39,14 +38,12 @@ class ReplaceRpmnewConfigs(Actor):
 
         for reponame in os.listdir(REPO_DIR):
             if LEAPP_SUFFIX in reponame:
-                repoconfig = []
-                with open(reponame) as o:
-                    for line in o.readlines():
-                        if line.startswith('enabled'):
-                            line = 'enabled = 0\n'
-                        repoconfig.append(line)
-                with open(reponame, 'w') as f:
-                    f.writelines(repoconfig)
+                repofile_path = os.path.join(REPO_DIR, reponame)
+                for line in fileinput.input(repofile_path, inplace=True):
+                    if line.startswith('enabled'):
+                        print("enabled = 0\n")
+                    else:
+                        print(line)
 
         if renamed_repofiles:
             replaced_string = '\n'.join(['- {}'.format(repofile_name) for repofile_name in renamed_repofiles])


### PR DESCRIPTION
This PR provides an actor that automatically replaces CloudLinux related RPM repository config files if there's a `.rpmnew` version present post-upgrade.

While this overrides any manual modifications made to said files (which is the likely reason for `.rpmnew` being created in the first place), the old configuration files are no longer valid on CloudLinux 8 at all, so keeping them as-is would serve no purpose anyway.

Instead, they're backed up, new files replace them, and a Leapp report with details of what was replaced is created.

This actor is theoretically extensible to any `.rpmnew` repofile, or, indeed, any `.rpmnew` file in general, but I opted to keep the scope limited to a known case for the moment.