### PR TITLE
Reorder logging workflow errors to avoid exiting the workflow with no error logged

### DIFF
--- a/commands/upgrade/__init__.py
+++ b/commands/upgrade/__init__.py
@@ -98,10 +98,10 @@ def upgrade(args, breadcrumbs):
 
     logger.info("Answerfile will be created at %s", answerfile_path)
     workflow.save_answers(answerfile_path, userchoices_path)
-    report_errors(workflow.errors)
     util.log_errors(workflow.errors, logger)
-    report_inhibitors(context)
     util.log_inhibitors(context, logger)
+    report_errors(workflow.errors)
+    report_inhibitors(context)
     util.generate_report_files(context, report_schema)
     report_files = util.get_cfg_files('report', cfg)
     log_files = util.get_cfg_files('logs', cfg)


### PR DESCRIPTION
Due to direct string handling in the Leapp tool itself, when running on Python 2 and encountering non-Unicode strings in logs, the process can fail and halt without any logs related to the actual cause of the failure - only the Unicode encoding error will be mentioned.

This patch will allow errors with Unicode strings to be logged before a potential Unicode formatting error can interrupt the process.