### PR TITLE
Extend DNF package workaround to have two lists - to reinstall and to delete

### DIFF
--- a/repos/system_upgrade/cloudlinux/actors/registerpackageworkarounds/actor.py
+++ b/repos/system_upgrade/cloudlinux/actors/registerpackageworkarounds/actor.py
@@ -1,13 +1,8 @@
 from leapp.actors import Actor
+from leapp.libraries.actor import registerpackageworkarounds
 from leapp.models import InstalledRPM, DNFWorkaround, PreRemovedRpmPackages
 from leapp.tags import FactsPhaseTag, IPUWorkflowTag
 from leapp.libraries.common.cllaunch import run_on_cloudlinux
-
-# NOTE: The related packages are listed both here *and* in the workaround script!
-# If the list changes, it has to change in both places.
-# This is a limitation of the current DNFWorkaround implementation.
-# TODO: unify the list in one place. A separate common file, perhaps?
-PACKAGE_LIST = ['gettext-devel', 'cloudlinux-fchange']
 
 
 class RegisterPackageWorkarounds(Actor):
@@ -23,22 +18,4 @@ class RegisterPackageWorkarounds(Actor):
 
     @run_on_cloudlinux
     def process(self):
-        preremoved_pkgs = PreRemovedRpmPackages(install=True)
-        # Only produce a message if a package is actually about to be uninstalled
-        for rpm_pkgs in self.consume(InstalledRPM):
-            for pkg in rpm_pkgs.items:
-                if (pkg.name in PACKAGE_LIST):
-                    preremoved_pkgs.items.append(pkg)
-                    self.log.debug("Listing package {} to be pre-removed".format(pkg.name))
-
-        if preremoved_pkgs.items:
-            self.produce(preremoved_pkgs)
-
-        self.produce(
-            # yum doesn't consider attempting to remove a non-existent package to be an error
-            # we can safely give it the entire package list without checking if all are installed
-            DNFWorkaround(
-                display_name='problem package modification',
-                script_path=self.get_tool_path('remove-problem-packages'),
-            )
-        )
+        registerpackageworkarounds.process()

--- a/repos/system_upgrade/cloudlinux/actors/registerpackageworkarounds/actor.py
+++ b/repos/system_upgrade/cloudlinux/actors/registerpackageworkarounds/actor.py
@@ -7,7 +7,7 @@ from leapp.libraries.common.cllaunch import run_on_cloudlinux
 # If the list changes, it has to change in both places.
 # This is a limitation of the current DNFWorkaround implementation.
 # TODO: unify the list in one place. A separate common file, perhaps?
-PACKAGE_LIST = ['gettext-devel']
+PACKAGE_LIST = ['gettext-devel', 'cloudlinux-fchange']
 
 
 class RegisterPackageWorkarounds(Actor):

--- a/repos/system_upgrade/cloudlinux/actors/registerpackageworkarounds/libraries/registerpackageworkarounds.py
+++ b/repos/system_upgrade/cloudlinux/actors/registerpackageworkarounds/libraries/registerpackageworkarounds.py
@@ -6,11 +6,13 @@ from leapp.libraries.stdlib import api
 # If the list changes, it has to change in both places.
 # This is a limitation of the current DNFWorkaround implementation.
 # TODO: unify the list in one place. A separate common file, perhaps?
-TO_REINSTALL = ['gettext-devel']
-TO_DELETE = ['cloudlinux-fchange']
+TO_REINSTALL = ['gettext-devel']  # These packages will be marked for installation
+TO_DELETE = []  # These won't be
 
 
 def produce_workaround_msg(pkg_list, reinstall):
+    if not pkg_list:
+        return
     preremoved_pkgs = PreRemovedRpmPackages(install=reinstall)
     # Only produce a message if a package is actually about to be uninstalled
     for rpm_pkgs in api.consume(InstalledRPM):

--- a/repos/system_upgrade/cloudlinux/actors/registerpackageworkarounds/libraries/registerpackageworkarounds.py
+++ b/repos/system_upgrade/cloudlinux/actors/registerpackageworkarounds/libraries/registerpackageworkarounds.py
@@ -1,0 +1,36 @@
+from leapp.actors import Actor
+from leapp.models import InstalledRPM, DNFWorkaround, PreRemovedRpmPackages
+from leapp.libraries.stdlib import api
+
+# NOTE: The related packages are listed both here *and* in the workaround script!
+# If the list changes, it has to change in both places.
+# This is a limitation of the current DNFWorkaround implementation.
+# TODO: unify the list in one place. A separate common file, perhaps?
+TO_REINSTALL = ['gettext-devel']
+TO_DELETE = ['cloudlinux-fchange']
+
+
+def produce_workaround_msg(pkg_list, reinstall):
+    preremoved_pkgs = PreRemovedRpmPackages(install=reinstall)
+    # Only produce a message if a package is actually about to be uninstalled
+    for rpm_pkgs in api.consume(InstalledRPM):
+        for pkg in rpm_pkgs.items:
+            if (pkg.name in pkg_list):
+                preremoved_pkgs.items.append(pkg)
+                api.log.debug("Listing package {} to be pre-removed".format(pkg.name))
+    if preremoved_pkgs.items:
+        api.produce(preremoved_pkgs)
+
+
+def process():
+    produce_workaround_msg(TO_REINSTALL, True)
+    produce_workaround_msg(TO_DELETE, False)
+
+    api.produce(
+        # yum doesn't consider attempting to remove a non-existent package to be an error
+        # we can safely give it the entire package list without checking if all are installed
+        DNFWorkaround(
+            display_name='problem package modification',
+            script_path=api.get_tool_path('remove-problem-packages'),
+        )
+    )

--- a/repos/system_upgrade/cloudlinux/actors/registerpackageworkarounds/libraries/registerpackageworkarounds.py
+++ b/repos/system_upgrade/cloudlinux/actors/registerpackageworkarounds/libraries/registerpackageworkarounds.py
@@ -19,7 +19,7 @@ def produce_workaround_msg(pkg_list, reinstall):
         for pkg in rpm_pkgs.items:
             if (pkg.name in pkg_list):
                 preremoved_pkgs.items.append(pkg)
-                api.log.debug("Listing package {} to be pre-removed".format(pkg.name))
+                api.current_logger().debug("Listing package {} to be pre-removed".format(pkg.name))
     if preremoved_pkgs.items:
         api.produce(preremoved_pkgs)
 

--- a/repos/system_upgrade/cloudlinux/tools/remove-problem-packages
+++ b/repos/system_upgrade/cloudlinux/tools/remove-problem-packages
@@ -1,4 +1,4 @@
 #!/usr/bin/bash -e
 
 # can't be removed in the main transaction due to errors in %preun
-yum -y --setopt=tsflags=noscripts remove gettext-devel cloudlinux-fchange
+yum -y --setopt=tsflags=noscripts remove gettext-devel

--- a/repos/system_upgrade/cloudlinux/tools/remove-problem-packages
+++ b/repos/system_upgrade/cloudlinux/tools/remove-problem-packages
@@ -1,4 +1,4 @@
 #!/usr/bin/bash -e
 
 # can't be removed in the main transaction due to errors in %preun
-yum -y --setopt=tsflags=noscripts remove gettext-devel
+yum -y --setopt=tsflags=noscripts remove gettext-devel cloudlinux-fchange


### PR DESCRIPTION
The new DNF workaround introduced in https://github.com/AlmaLinux/leapp-repository/pull/45 had only one list of packages to be removed - all packages in that list would be uninstalled (without running %PREUN, %POSTUN scriptlets), and marked for installation in the main transaction.

However, we don't always want to reinstall them. Some might not even exist in the new repositories for the target system. Therefore, the list is split into two - list of packages to be reinstalled after deletion, and list of those that are just deleted.