### PR TITLE
CL: Allow unknown and integrated webpanel upgrades

### DIFF
--- a/repos/system_upgrade/cloudlinux/actors/detectcontrolpanel/actor.py
+++ b/repos/system_upgrade/cloudlinux/actors/detectcontrolpanel/actor.py
@@ -7,6 +7,7 @@ from leapp.libraries.common.cllaunch import run_on_cloudlinux
 from leapp.libraries.actor.detectcontrolpanel import (
     detect_panel,
     UNKNOWN_NAME,
+    INTEGRATED_NAME,
     CPANEL_NAME,
 )
 
@@ -27,13 +28,10 @@ class DetectControlPanel(Actor):
 
         if panel == CPANEL_NAME:
             self.log.debug('cPanel detected, upgrade proceeding')
+        elif panel == INTEGRATED_NAME or panel == UNKNOWN_NAME:
+            self.log.debug('Integrated/no panel detected, upgrade proceeding')
         elif panel:
             summary_info = "Detected panel: {}".format(panel)
-            if panel == UNKNOWN_NAME:
-                summary_info = (
-                    "Legacy custom panel script detected in CloudLinux configuration"
-                )
-
             # Block the upgrade on any systems with a panel detected.
             reporting.create_report(
                 [


### PR DESCRIPTION
Previously if any web-panels except cPanel were detected, the upgrade was blocked.

Now it is possible to proceed with Integrated panels as well.