### PR TITLE
Don't list cPanel packages in leftover list

### DIFF
--- a/repos/system_upgrade/el7toel8/actors/checkleftoverpackages/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/checkleftoverpackages/actor.py
@@ -1,7 +1,23 @@
 from leapp.actors import Actor
 from leapp.libraries.common.rpms import get_installed_rpms
-from leapp.models import LeftoverPackages, TransactionCompleted, InstalledUnsignedRPM, RPM
+from leapp.models import (
+    LeftoverPackages,
+    TransactionCompleted,
+    InstalledUnsignedRPM,
+    RPM,
+)
 from leapp.tags import RPMUpgradePhaseTag, IPUWorkflowTag
+
+LEAPP_PACKAGES = [
+    "leapp",
+    "leapp-repository",
+    "snactor",
+    "leapp-repository-deps-el8",
+    "leapp-deps-el8",
+    "python2-leapp",
+]
+
+CPANEL_SUFFIX = "cpanel-"
 
 
 class CheckLeftoverPackages(Actor):
@@ -11,36 +27,50 @@ class CheckLeftoverPackages(Actor):
     Actor produces message containing these packages. Message is empty if there are no el7 package left.
     """
 
-    name = 'check_leftover_packages'
+    name = "check_leftover_packages"
     consumes = (TransactionCompleted, InstalledUnsignedRPM)
     produces = (LeftoverPackages,)
     tags = (RPMUpgradePhaseTag, IPUWorkflowTag)
 
+    def skip_leftover_pkg(self, name, unsigned_set):
+        # Packages like these are expected to be not updated.
+        is_unsigned = name not in unsigned_set
+        # Packages like these are updated outside of Leapp.
+        is_external = name.startswith(CPANEL_SUFFIX)
+
+        return is_unsigned or is_external
+
     def process(self):
-        LEAPP_PACKAGES = ['leapp', 'leapp-repository', 'snactor', 'leapp-repository-deps-el8', 'leapp-deps-el8',
-                          'python2-leapp']
         installed_rpms = get_installed_rpms()
         if not installed_rpms:
             return
 
         to_remove = LeftoverPackages()
-        unsigned = [pkg.name for pkg in next(self.consume(InstalledUnsignedRPM), InstalledUnsignedRPM()).items]
+        unsigned = [
+            pkg.name
+            for pkg in next(
+                self.consume(InstalledUnsignedRPM), InstalledUnsignedRPM()
+            ).items
+        ]
+        unsigned_set = set(unsigned + LEAPP_PACKAGES)
 
         for rpm in installed_rpms:
             rpm = rpm.strip()
             if not rpm:
                 continue
-            name, version, release, epoch, packager, arch, pgpsig = rpm.split('|')
+            name, version, release, epoch, packager, arch, pgpsig = rpm.split("|")
 
-            if 'el7' in release and name not in set(unsigned + LEAPP_PACKAGES):
-                to_remove.items.append(RPM(
-                    name=name,
-                    version=version,
-                    epoch=epoch,
-                    packager=packager,
-                    arch=arch,
-                    release=release,
-                    pgpsig=pgpsig
-                ))
+            if "el7" in release and not self.skip_leftover_pkg(name, unsigned_set):
+                to_remove.items.append(
+                    RPM(
+                        name=name,
+                        version=version,
+                        epoch=epoch,
+                        packager=packager,
+                        arch=arch,
+                        release=release,
+                        pgpsig=pgpsig,
+                    )
+                )
 
         self.produce(to_remove)


### PR DESCRIPTION
cPanel packages, if present, are updated separately from the main Leapp upgrade process via `elevate-cpanel`. This is done after the Leapp upgrade finishes.

From Leapp's perspective, the cPanel packages appear to be intended for an upgrade, but remain the same version as before the upgrade started - el7. This results in the final report listing all cPanel packages as "leftover", and requesting the user to remove them. This is a false positive.

Since cPanel packages are not signed and have no publisher, we can only filter them based on names. This modification of the `check_leftover_packages` actor ensures that they're not included in any leftover package lists or reports.