### PR TITLE
Extend MySQL detection logic for multiple installations, add file backup

### DIFF
--- a/repos/system_upgrade/cloudlinux/actors/backupmysqldata/actor.py
+++ b/repos/system_upgrade/cloudlinux/actors/backupmysqldata/actor.py
@@ -1,6 +1,6 @@
 import os
 from leapp.actors import Actor
-from leapp.tags import InterimPreparationPhase, IPUWorkflowTag
+from leapp.tags import InterimPreparationPhaseTag, IPUWorkflowTag
 from leapp.libraries.common.cllaunch import run_on_cloudlinux
 from leapp.libraries.common.backup import backup_file, CLSQL_BACKUP_FILES
 
@@ -13,7 +13,7 @@ class BackupMySqlData(Actor):
     name = 'backup_my_sql_data'
     consumes = ()
     produces = ()
-    tags = (InterimPreparationPhase.Before, IPUWorkflowTag)
+    tags = (InterimPreparationPhaseTag.Before, IPUWorkflowTag)
 
     @run_on_cloudlinux
     def process(self):

--- a/repos/system_upgrade/cloudlinux/actors/backupmysqldata/actor.py
+++ b/repos/system_upgrade/cloudlinux/actors/backupmysqldata/actor.py
@@ -1,0 +1,22 @@
+import os
+from leapp.actors import Actor
+from leapp.tags import InterimPreparationPhase, IPUWorkflowTag
+from leapp.libraries.common.cllaunch import run_on_cloudlinux
+from leapp.libraries.common.backup import backup_file, CLSQL_BACKUP_FILES
+
+
+class BackupMySqlData(Actor):
+    """
+    Backup cl-mysql configuration data to an external folder.
+    """
+
+    name = 'backup_my_sql_data'
+    consumes = ()
+    produces = ()
+    tags = (InterimPreparationPhase.Before, IPUWorkflowTag)
+
+    @run_on_cloudlinux
+    def process(self):
+        for filename in CLSQL_BACKUP_FILES:
+            if os.path.isfile(filename):
+                backup_file(filename, os.path.basename(filename))

--- a/repos/system_upgrade/cloudlinux/actors/checkcllicense/actor.py
+++ b/repos/system_upgrade/cloudlinux/actors/checkcllicense/actor.py
@@ -1,5 +1,6 @@
 from leapp.actors import Actor
 from leapp import reporting
+from leapp.reporting import Report
 from leapp.tags import ChecksPhaseTag, IPUWorkflowTag
 from leapp.libraries.stdlib import CalledProcessError, run
 from leapp.libraries.common.cllaunch import run_on_cloudlinux
@@ -14,7 +15,7 @@ class CheckClLicense(Actor):
 
     name = 'check_cl_license'
     consumes = ()
-    produces = ()
+    produces = (Report,)
     tags = (ChecksPhaseTag, IPUWorkflowTag)
 
     system_id_path = '/etc/sysconfig/rhn/systemid'

--- a/repos/system_upgrade/cloudlinux/actors/checkrhnversionoverride/actor.py
+++ b/repos/system_upgrade/cloudlinux/actors/checkrhnversionoverride/actor.py
@@ -1,5 +1,6 @@
 from leapp.actors import Actor
 from leapp import reporting
+from leapp.reporting import Report
 from leapp.tags import ChecksPhaseTag, IPUWorkflowTag
 from leapp.libraries.common.cllaunch import run_on_cloudlinux
 
@@ -11,7 +12,7 @@ class CheckRhnVersionOverride(Actor):
 
     name = 'check_rhn_version_override'
     consumes = ()
-    produces = ()
+    produces = (Report,)
     tags = (ChecksPhaseTag, IPUWorkflowTag)
 
     @run_on_cloudlinux

--- a/repos/system_upgrade/cloudlinux/actors/clmysqlrepositorysetup/libraries/clmysqlrepositorysetup.py
+++ b/repos/system_upgrade/cloudlinux/actors/clmysqlrepositorysetup/libraries/clmysqlrepositorysetup.py
@@ -69,7 +69,7 @@ def process():
         if repofile_full.endswith(LEAPP_COPY_SUFFIX) or not repofile_full.endswith(REPOFILE_SUFFIX):
             continue
         # Cut the .repo part to get only the name.
-        repofile_name = repofile_full[:-5]
+        repofile_name = repofile_full[:-len(REPOFILE_SUFFIX)]
         full_repo_path = os.path.join(REPO_DIR, repofile_full)
 
         # Parse any repository files that may have something to do with MySQL or MariaDB.

--- a/repos/system_upgrade/cloudlinux/actors/clmysqlrepositorysetup/libraries/clmysqlrepositorysetup.py
+++ b/repos/system_upgrade/cloudlinux/actors/clmysqlrepositorysetup/libraries/clmysqlrepositorysetup.py
@@ -182,23 +182,38 @@ def process():
 
     if len(mysql_types) == 0:
         api.current_logger().debug('No installed MySQL/MariaDB detected')
-    elif len(mysql_types) == 1:
-        api.current_logger().debug('Detected MySQL/MariaDB type: {}, version: {}'.format(mysql_types[0], clmysql_type))
     else:
-        api.current_logger().warning('Detected multiple MySQL types: {}'.format(", ".join(mysql_types)))
         reporting.create_report([
-            reporting.Title('Multpile MySQL/MariaDB versions detected'),
+            reporting.Title('MySQL database backup recommended'),
             reporting.Summary(
-                'Package repositories for multiple distributions of MySQL/MariaDB '
-                'were detected on the system. '
-                'Leapp will attempt to update all distributions detected. '
-                'To update only the distribution you use, disable YUM package repositories for all '
-                'other distributions. '
-                'Detected: {0}'.format(", ".join(mysql_types))
+                'A MySQL/MariaDB installation has been detected on this machine. '
+                'It is recommended to make a database backup before proceeding with the upgrade.'
             ),
-            reporting.Severity(reporting.Severity.MEDIUM),
-            reporting.Tags([reporting.Tags.REPOSITORY, reporting.Tags.OS_FACTS]),
+            reporting.Severity(reporting.Severity.HIGH),
+            reporting.Tags([reporting.Tags.REPOSITORY]),
         ])
+
+        if len(mysql_types) == 1:
+            api.current_logger().debug(
+                "Detected MySQL/MariaDB type: {}, version: {}".format(
+                    mysql_types[0], clmysql_type
+                )
+            )
+        else:
+            api.current_logger().warning('Detected multiple MySQL types: {}'.format(", ".join(mysql_types)))
+            reporting.create_report([
+                reporting.Title('Multpile MySQL/MariaDB versions detected'),
+                reporting.Summary(
+                    'Package repositories for multiple distributions of MySQL/MariaDB '
+                    'were detected on the system. '
+                    'Leapp will attempt to update all distributions detected. '
+                    'To update only the distribution you use, disable YUM package repositories for all '
+                    'other distributions. '
+                    'Detected: {0}'.format(", ".join(mysql_types))
+                ),
+                reporting.Severity(reporting.Severity.MEDIUM),
+                reporting.Tags([reporting.Tags.REPOSITORY, reporting.Tags.OS_FACTS]),
+            ])
 
     if 'cloudlinux' in mysql_types and clmysql_type in MODULE_STREAMS.keys():
         mod_name, mod_stream = MODULE_STREAMS[clmysql_type].split(':')

--- a/repos/system_upgrade/cloudlinux/actors/clmysqlrepositorysetup/libraries/clmysqlrepositorysetup.py
+++ b/repos/system_upgrade/cloudlinux/actors/clmysqlrepositorysetup/libraries/clmysqlrepositorysetup.py
@@ -62,6 +62,7 @@ def build_install_list(prefix):
 def process():
     mysql_types = []
     clmysql_type = None
+    custom_repo_msgs = []
 
     for repofile_full in os.listdir(REPO_DIR):
         # Don't touch non-repository files or copied repofiles created by Leapp.
@@ -77,7 +78,12 @@ def process():
         # Process CL-provided options.
         if any(mark in repofile_name for mark in CL_MARKERS):
             repofile_data = repofileutils.parse_repofile(full_repo_path)
-            api.current_logger().debug('Data from repofile: {}'.format(repofile_data.data))
+            data_to_log = [
+                (repo_data.repoid, "enabled" if repo_data.enabled else "disabled")
+                for repo_data in repofile_data.data
+            ]
+
+            api.current_logger().debug('repoids from CloudLinux repofile {}: {}'.format(repofile_name, data_to_log))
 
             # Were any repositories enabled?
             for repo in repofile_data.data:
@@ -87,15 +93,14 @@ def process():
                 repo.repoid = repo.repoid + '-8'
                 # releasever may be something like 8.6, while only 8 is acceptable.
                 repo.baseurl = repo.baseurl.replace('/cl$releasever/', '/cl8/')
+
                 # mysqlclient is usually disabled when installed from CL MySQL Governor.
                 # However, it should be enabled for the Leapp upgrade, seeing as some packages
                 # from it won't update otherwise.
-
                 if repo.enabled or repo.repoid == 'mysqclient-8':
-                    mysql_types.append('cloudlinux')
                     clmysql_type = get_clmysql_type()
                     api.current_logger().debug('Generating custom cl-mysql repo: {}'.format(repo.repoid))
-                    api.produce(CustomTargetRepository(
+                    custom_repo_msgs.append(CustomTargetRepository(
                         repoid=repo.repoid,
                         name=repo.name,
                         baseurl=repo.baseurl,
@@ -103,7 +108,12 @@ def process():
                     ))
 
             if any(repo.enabled for repo in repofile_data.data):
+                mysql_types.append('cloudlinux')
                 produce_leapp_repofile_copy(repofile_data, repofile_name)
+            else:
+                api.current_logger().debug("No repos from CloudLinux repofile {} enabled, ignoring".format(
+                        repofile_name
+                    ))
 
         # Process MariaDB options.
         elif any(mark in repofile_name for mark in MARIA_MARKERS):
@@ -116,13 +126,12 @@ def process():
                 # We want to replace the 7 in OS name after /yum/
                 repo.repoid = repo.repoid + '-8'
                 if repo.enabled:
-                    mysql_types.append('mariadb')
                     url_parts = repo.baseurl.split('yum')
                     url_parts[1] = 'yum' + url_parts[1].replace('7', '8')
                     repo.baseurl = ''.join(url_parts)
 
                     api.current_logger().debug('Generating custom MariaDB repo: {}'.format(repo.repoid))
-                    api.produce(CustomTargetRepository(
+                    custom_repo_msgs.append(CustomTargetRepository(
                         repoid=repo.repoid,
                         name=repo.name,
                         baseurl=repo.baseurl,
@@ -132,7 +141,12 @@ def process():
             if any(repo.enabled for repo in repofile_data.data):
                 # Since MariaDB URLs have major versions written in, we need a new repo file
                 # to feed to the target userspace.
+                mysql_types.append('mariadb')
                 produce_leapp_repofile_copy(repofile_data, repofile_name)
+            else:
+                api.current_logger().debug("No repos from MariaDB repofile {} enabled, ignoring".format(
+                        repofile_name
+                    ))
 
         # Process MySQL options.
         elif any(mark in repofile_name for mark in MYSQL_MARKERS):
@@ -140,7 +154,6 @@ def process():
 
             for repo in repofile_data.data:
                 if repo.enabled:
-                    mysql_types.append('mysql')
                     # MySQL package repos don't have these versions available for EL8 anymore.
                     # There'll be nothing to upgrade to.
                     # CL repositories do provide them, though.
@@ -170,7 +183,7 @@ def process():
                         repo.repoid = repo.repoid + '-8'
                         repo.baseurl = repo.baseurl.replace('/el/7/', '/el/8/')
                         api.current_logger().debug('Generating custom MySQL repo: {}'.format(repo.repoid))
-                        api.produce(CustomTargetRepository(
+                        custom_repo_msgs.append(CustomTargetRepository(
                             repoid=repo.repoid,
                             name=repo.name,
                             baseurl=repo.baseurl,
@@ -178,7 +191,12 @@ def process():
                         ))
 
             if any(repo.enabled for repo in repofile_data.data):
+                mysql_types.append('mysql')
                 produce_leapp_repofile_copy(repofile_data, repofile_name)
+            else:
+                api.current_logger().debug("No repos from MySQL repofile {} enabled, ignoring".format(
+                        repofile_name
+                    ))
 
     if len(mysql_types) == 0:
         api.current_logger().debug('No installed MySQL/MariaDB detected')
@@ -192,6 +210,9 @@ def process():
             reporting.Severity(reporting.Severity.HIGH),
             reporting.Tags([reporting.Tags.REPOSITORY]),
         ])
+
+        for msg in custom_repo_msgs:
+            api.produce(msg)
 
         if len(mysql_types) == 1:
             api.current_logger().debug(

--- a/repos/system_upgrade/cloudlinux/actors/enableyumspacewalkplugin/actor.py
+++ b/repos/system_upgrade/cloudlinux/actors/enableyumspacewalkplugin/actor.py
@@ -1,6 +1,7 @@
 from leapp.actors import Actor
 from leapp.tags import FirstBootPhaseTag, IPUWorkflowTag
 from leapp import reporting
+from leapp.reporting import Report
 from leapp.libraries.common.cllaunch import run_on_cloudlinux
 
 try:
@@ -21,7 +22,7 @@ class EnableYumSpacewalkPlugin(Actor):
 
     name = 'enable_yum_spacewalk_plugin'
     consumes = ()
-    produces = ()
+    produces = (Report,)
     tags = (FirstBootPhaseTag, IPUWorkflowTag)
 
     config = '/etc/yum/pluginconf.d/spacewalk.conf'

--- a/repos/system_upgrade/cloudlinux/actors/replacerpmnewconfigs/actor.py
+++ b/repos/system_upgrade/cloudlinux/actors/replacerpmnewconfigs/actor.py
@@ -38,6 +38,7 @@ class ReplaceRpmnewConfigs(Actor):
                 os.rename(new_file_path, base_path)
                 renamed_repofiles.append(base_reponame)
 
+        # Disable any old repositories.
         for reponame in os.listdir(REPO_DIR):
             if LEAPP_BACKUP_SUFFIX in reponame:
                 repofile_path = os.path.join(REPO_DIR, reponame)

--- a/repos/system_upgrade/cloudlinux/actors/restoremysqldata/actor.py
+++ b/repos/system_upgrade/cloudlinux/actors/restoremysqldata/actor.py
@@ -1,8 +1,8 @@
 import os
 from leapp.actors import Actor
-from leapp.tags import ThirdPartyApplicationsPhase, IPUWorkflowTag
+from leapp.tags import ThirdPartyApplicationsPhaseTag, IPUWorkflowTag
 from leapp.libraries.common.cllaunch import run_on_cloudlinux
-from leapp.libraries.common.backup import backup_file, CLSQL_BACKUP_FILES
+from leapp.libraries.common.backup import restore_file, CLSQL_BACKUP_FILES
 
 
 class RestoreMySqlData(Actor):
@@ -13,10 +13,10 @@ class RestoreMySqlData(Actor):
     name = 'restore_my_sql_data'
     consumes = ()
     produces = ()
-    tags = (ThirdPartyApplicationsPhase, IPUWorkflowTag)
+    tags = (ThirdPartyApplicationsPhaseTag, IPUWorkflowTag)
 
     @run_on_cloudlinux
     def process(self):
         for filename in CLSQL_BACKUP_FILES:
             if os.path.isfile(filename):
-                backup_file(filename, os.path.basename(filename))
+                restore_file(filename, os.path.basename(filename))

--- a/repos/system_upgrade/cloudlinux/actors/restoremysqldata/actor.py
+++ b/repos/system_upgrade/cloudlinux/actors/restoremysqldata/actor.py
@@ -1,0 +1,22 @@
+import os
+from leapp.actors import Actor
+from leapp.tags import ThirdPartyApplicationsPhase, IPUWorkflowTag
+from leapp.libraries.common.cllaunch import run_on_cloudlinux
+from leapp.libraries.common.backup import backup_file, CLSQL_BACKUP_FILES
+
+
+class RestoreMySqlData(Actor):
+    """
+    Restore cl-mysql configuration data from an external folder.
+    """
+
+    name = 'restore_my_sql_data'
+    consumes = ()
+    produces = ()
+    tags = (ThirdPartyApplicationsPhase, IPUWorkflowTag)
+
+    @run_on_cloudlinux
+    def process(self):
+        for filename in CLSQL_BACKUP_FILES:
+            if os.path.isfile(filename):
+                backup_file(filename, os.path.basename(filename))

--- a/repos/system_upgrade/cloudlinux/actors/switchclnchannel/actor.py
+++ b/repos/system_upgrade/cloudlinux/actors/switchclnchannel/actor.py
@@ -4,6 +4,7 @@ from leapp.tags import DownloadPhaseTag, IPUWorkflowTag
 from leapp.libraries.stdlib import CalledProcessError, run
 from leapp.libraries.common.cllaunch import run_on_cloudlinux
 from leapp import reporting
+from leapp.reporting import Report
 
 
 class SwitchClnChannel(Actor):
@@ -13,7 +14,7 @@ class SwitchClnChannel(Actor):
 
     name = "switch_cln_channel"
     consumes = ()
-    produces = ()
+    produces = (Report,)
     tags = (IPUWorkflowTag, DownloadPhaseTag.Before)
 
     switch_bin = "/usr/sbin/cln-switch-channel"

--- a/repos/system_upgrade/cloudlinux/actors/updatecagefs/actor.py
+++ b/repos/system_upgrade/cloudlinux/actors/updatecagefs/actor.py
@@ -3,7 +3,6 @@ import os
 from leapp.actors import Actor
 from leapp.libraries.stdlib import run, CalledProcessError
 from leapp.reporting import Report, create_report
-from leapp import reporting
 from leapp.tags import FirstBootPhaseTag, IPUWorkflowTag
 from leapp.libraries.common.cllaunch import run_on_cloudlinux
 
@@ -17,7 +16,7 @@ class UpdateCagefs(Actor):
 
     name = 'update_cagefs'
     consumes = ()
-    produces = ()
+    produces = (Report,)
     tags = (FirstBootPhaseTag, IPUWorkflowTag)
 
     @run_on_cloudlinux
@@ -29,7 +28,9 @@ class UpdateCagefs(Actor):
             except CalledProcessError as e:
                 # cagefsctl prints errors in stdout
                 self.log.error(e.stdout)
-                self.log.error('Command "cagefsctl --force-update" finished with exit code {}, '
+                self.log.error
+                (
+                    'Command "cagefsctl --force-update" finished with exit code {}, '
                     'the filesystem inside cagefs may be out-of-date.\n'
                     'Check cagefsctl output above and in /var/log/cagefs-update.log, '
                     'rerun "cagefsctl --force-update" after fixing the issues.'.format(e.exit_code)

--- a/repos/system_upgrade/cloudlinux/libraries/backup.py
+++ b/repos/system_upgrade/cloudlinux/libraries/backup.py
@@ -1,0 +1,49 @@
+import os
+import shutil
+from leapp.libraries.stdlib import api
+
+CLSQL_BACKUP_FILES = [
+    "/etc/container/dbuser-map",
+    "/etc/container/ve.cfg",
+    "/etc/container/mysql-governor.xml",
+    "/etc/container/governor_package_limit.json"
+]
+
+BACKUP_DIR = "/var/lib/leapp/cl_backup"
+
+
+def backup_file(source, destination, dir=None):
+    # type: (str, str, str) -> None
+    """
+    Backup file to a backup directory.
+
+    :param source: Path of the file to backup.
+    :param destination: Destination name of a file in the backup directory.
+    :param dir: Backup directory override, defaults to None
+    """
+    if not dir:
+        dir = BACKUP_DIR
+    if not os.path.isdir(dir):
+        os.makedirs(dir)
+
+    dest_path = os.path.join(dir, destination)
+
+    api.current_logger().debug('Backing up file: {} to {}'.format(source, dest_path))
+    shutil.copy(source, dest_path)
+
+
+def restore_file(source, destination, dir=None):
+    # type: (str, str, str) -> None
+    """
+    Restore file from a backup directory.
+
+    :param source: Name of a file in the backup directory.
+    :param destination: Destination path to restore the file to.
+    :param dir: Backup directory override, defaults to None
+    """
+    if not dir:
+        dir = BACKUP_DIR
+    src_path = os.path.join(dir, source)
+
+    api.current_logger().debug('Restoring file: {} to {}'.format(src_path, destination))
+    shutil.copy(src_path, destination)

--- a/repos/system_upgrade/common/actors/detectwebservers/actor.py
+++ b/repos/system_upgrade/common/actors/detectwebservers/actor.py
@@ -31,7 +31,7 @@ class DetectWebServers(Actor):
                         "An installed web server might not be upgraded properly."
                     ),
                     reporting.Summary(
-                        "A {} web server is present on the system."
+                        "A web server is present on the system."
                         " Depending on the source of installation, "
                         " it may not upgrade to the new version correctly,"
                         " since not all installation configurations are currently supported by Leapp."
@@ -41,7 +41,8 @@ class DetectWebServers(Actor):
                         " If the web server packages are present in the list of packages that won't be upgraded,"
                         " expect the server to be non-functional on the post-upgrade system."
                         " You may still continue with the upgrade, but you'll need to"
-                        " upgrade the web server manually after the process finishes.".format(server_name)
+                        " upgrade the web server manually after the process finishes."
+                        " Detected webserver: {}.".format(server_name)
                     ),
                     reporting.Severity(reporting.Severity.HIGH),
                     reporting.Tags([

--- a/repos/system_upgrade/common/actors/detectwebservers/actor.py
+++ b/repos/system_upgrade/common/actors/detectwebservers/actor.py
@@ -31,12 +31,17 @@ class DetectWebServers(Actor):
                         "An installed web server might not be upgraded properly."
                     ),
                     reporting.Summary(
-                        "A web server is present on the system."
+                        "A NGINX/LiteSpeed web server is present on the system."
                         " Depending on the source of installation, "
                         " it may not upgrade to the new version correctly,"
-                        " since not all varoants are currently supported by Leapp."
-                        " Please check the list of packages that won't be upgraded in the report."
-                        " Alternatively, upgrade the webserver manually after the process finishes."
+                        " since not all installation configurations are currently supported by Leapp."
+                        " Failing to upgrade the webserver may result in it malfunctioning"
+                        " after the upgrade process finishes."
+                        " Please review the list of packages that won't be upgraded in the report."
+                        " If the web server packages are present in the list of packages that won't be upgraded,"
+                        " expect the server to be non-functional on the post-upgrade system."
+                        " You may still continue with the upgrade, but you'll need to"
+                        " upgrade the web server manually after the process finishes."
                         " Detected webserver: {}.".format(server_name)
                     ),
                     reporting.Severity(reporting.Severity.HIGH),

--- a/repos/system_upgrade/common/actors/detectwebservers/actor.py
+++ b/repos/system_upgrade/common/actors/detectwebservers/actor.py
@@ -31,7 +31,7 @@ class DetectWebServers(Actor):
                         "An installed web server might not be upgraded properly."
                     ),
                     reporting.Summary(
-                        "A NGINX/LiteSpeed web server is present on the system."
+                        "A {} web server is present on the system."
                         " Depending on the source of installation, "
                         " it may not upgrade to the new version correctly,"
                         " since not all installation configurations are currently supported by Leapp."
@@ -41,8 +41,7 @@ class DetectWebServers(Actor):
                         " If the web server packages are present in the list of packages that won't be upgraded,"
                         " expect the server to be non-functional on the post-upgrade system."
                         " You may still continue with the upgrade, but you'll need to"
-                        " upgrade the web server manually after the process finishes."
-                        " Detected webserver: {}.".format(server_name)
+                        " upgrade the web server manually after the process finishes.".format(server_name)
                     ),
                     reporting.Severity(reporting.Severity.HIGH),
                     reporting.Tags([

--- a/repos/system_upgrade/common/libraries/repofileutils.py
+++ b/repos/system_upgrade/common/libraries/repofileutils.py
@@ -64,7 +64,7 @@ def save_repofile(repodata, repofile_path):
     :type repofile_path: str
     """
     with open(repofile_path, mode='w') as fp:
-        cp = utils.create_config(repodata)
+        cp = utils.create_parser()
         _prepare_config(repodata, cp)
         cp.write(fp)
 

--- a/repos/system_upgrade/common/libraries/utils.py
+++ b/repos/system_upgrade/common/libraries/utils.py
@@ -43,7 +43,7 @@ def parse_config(cfg=None, strict=True):
     return parser
 
 
-def create_config(repodata):
+def create_parser(strict=True):
     if six.PY3:
         parser = six.moves.configparser.ConfigParser(strict=strict)  # pylint: disable=unexpected-keyword-arg
     else:

--- a/repos/system_upgrade/el7toel8/actors/opensshpermitrootlogincheck/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/opensshpermitrootlogincheck/actor.py
@@ -54,8 +54,8 @@ class OpenSshPermitRootLoginCheck(Actor):
                     'to log onto this machine after the upgrade. '
                     'To prevent this from occuring, the PermitRootLogin option '
                     'has been explicity set to "yes" to preserve the default behaivour '
-                    'after migration.'
-                    'The original configuration file has been backed up to'
+                    'after migration. '
+                    'The original configuration file has been backed up to '
                     '/etc/ssh/sshd_config.leapp_backup'
                 ),
                 reporting.Severity(reporting.Severity.MEDIUM),


### PR DESCRIPTION
It's possible that a user can have several MySQL/MariaDB configurations installed on the machine.
This is a rather unstable case, but Leapp can't make decisions on what to upgrade and what to keep on its own.
It seems like the best option is to let the user know in the preupgrade check, and let them decide what to do.

In addition, some configuration files should be migrated together with the upgrade.
Full automatic database backup seems untenable, considering how large a server DB can get. A successful backup is not even guaranteed, depending on the free space available.