### PR TITLE
Strip config lines while reading rhn/up2date

### DIFF
--- a/repos/system_upgrade/cloudlinux/actors/checkrhnversionoverride/actor.py
+++ b/repos/system_upgrade/cloudlinux/actors/checkrhnversionoverride/actor.py
@@ -20,7 +20,7 @@ class CheckRhnVersionOverride(Actor):
         with open(up2date_config, 'r') as f:
             config_data = f.readlines()
             for line in config_data:
-                if line.startswith('versionOverride=') and line != 'versionOverride=':
+                if line.startswith('versionOverride=') and line.strip() != 'versionOverride=':
                     title = 'RHN up2date: versionOverride not empty'
                     summary = ('The RHN config file up2date has a set value of the versionOverride option.'
                                ' This value will get overwritten by the upgrade process, and non-supported values'


### PR DESCRIPTION
Small correction to the actor checking rhn/up2date config file:
The checked line should be stripped of whitespace symbols to avoid possible false positives.