### PR TITLE
Correct active vendor checks and leftover package filtering

### DIFF
--- a/repos/system_upgrade/cloudlinux/actors/restoremysqldata/actor.py
+++ b/repos/system_upgrade/cloudlinux/actors/restoremysqldata/actor.py
@@ -1,8 +1,10 @@
 import os
 from leapp.actors import Actor
+from leapp import reporting
+from leapp.models import Report
 from leapp.tags import ThirdPartyApplicationsPhaseTag, IPUWorkflowTag
 from leapp.libraries.common.cllaunch import run_on_cloudlinux
-from leapp.libraries.common.backup import restore_file, CLSQL_BACKUP_FILES
+from leapp.libraries.common.backup import restore_file, CLSQL_BACKUP_FILES, BACKUP_DIR
 
 
 class RestoreMySqlData(Actor):
@@ -12,11 +14,33 @@ class RestoreMySqlData(Actor):
 
     name = 'restore_my_sql_data'
     consumes = ()
-    produces = ()
+    produces = (Report,)
     tags = (ThirdPartyApplicationsPhaseTag, IPUWorkflowTag)
 
     @run_on_cloudlinux
     def process(self):
-        for filename in CLSQL_BACKUP_FILES:
-            if os.path.isfile(filename):
-                restore_file(filename, os.path.basename(filename))
+        failed_files = []
+
+        for filepath in CLSQL_BACKUP_FILES:
+            try:
+                restore_file(os.path.basename(filepath), filepath)
+            except OSError as e:
+                failed_files.append(filepath)
+                self.log.error('Could not restore file {}: {}'.format(filepath, e.strerror))
+
+        if failed_files:
+            title = "Failed to restore backed up configuration files"
+            summary = (
+                "Some backed up configuration files were unable to be restored automatically."
+                " Please check the upgrade log for detailed error descriptions"
+                " and restore the files from the backup directory {} manually if needed."
+                " Files not restored: {}".format(BACKUP_DIR, failed_files)
+            )
+            reporting.create_report(
+                [
+                    reporting.Title(title),
+                    reporting.Summary(summary),
+                    reporting.Severity(reporting.Severity.HIGH),
+                    reporting.Tags([reporting.Tags.UPGRADE_PROCESS]),
+                ]
+            )

--- a/repos/system_upgrade/common/actors/checkenabledvendorrepos/actor.py
+++ b/repos/system_upgrade/common/actors/checkenabledvendorrepos/actor.py
@@ -10,7 +10,7 @@ from leapp.tags import FactsPhaseTag, IPUWorkflowTag
 
 class CheckEnabledVendorRepos(Actor):
     """
-    Create a list of vendors whose repositories are present on the system.
+    Create a list of vendors whose repositories are present on the system and enabled.
     Only those vendors' configurations (new repositories, PES actions, etc.)
     will be included in the upgrade process.
     """
@@ -24,24 +24,24 @@ class CheckEnabledVendorRepos(Actor):
         vendor_mapping_data = {}
         active_vendors = set()
 
-        # Make a dict for easy lookup of repoid -> vendor name.
+        # Make a dict for easy mapping of repoid -> corresponding vendor name.
         for vendor_src_repodata in api.consume(VendorSourceRepos):
             for vendor_src_repo in vendor_src_repodata.source_repoids:
                 vendor_mapping_data[vendor_src_repo] = vendor_src_repodata.vendor
 
         # Is the repo listed in the vendor map as from_repoid present on the system?
-        for repos in api.consume(RepositoriesFacts):
-            for repo_file in repos.repositories:
-                for repo in repo_file.data:
+        for repos_facts in api.consume(RepositoriesFacts):
+            for repo_file in repos_facts.repositories:
+                for repo_data in repo_file.data:
                     self.log.debug(
-                        "Looking for repository {} in vendor maps".format(repo.repoid)
+                        "Looking for repository {} in vendor maps".format(repo_data.repoid)
                     )
-                    if repo.repoid in vendor_mapping_data:
-                        # If the vendor's repository is present in the system, count the vendor as active.
-                        new_vendor = vendor_mapping_data[repo.repoid]
+                    if repo_data.enabled and repo_data.repoid in vendor_mapping_data:
+                        # If the vendor's repository is present in the system and enabled, count the vendor as active.
+                        new_vendor = vendor_mapping_data[repo_data.repoid]
                         self.log.debug(
-                            "Repository {} found, enabling vendor {}".format(
-                                repo.repoid, new_vendor
+                            "Repository {} found and enabled, enabling vendor {}".format(
+                                repo_data.repoid, new_vendor
                             )
                         )
                         active_vendors.add(new_vendor)

--- a/repos/system_upgrade/el7toel8/actors/checkleftoverpackages/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/checkleftoverpackages/actor.py
@@ -34,7 +34,7 @@ class CheckLeftoverPackages(Actor):
 
     def skip_leftover_pkg(self, name, unsigned_set):
         # Packages like these are expected to be not updated.
-        is_unsigned = name not in unsigned_set
+        is_unsigned = name in unsigned_set
         # Packages like these are updated outside of Leapp.
         is_external = name.startswith(CPANEL_SUFFIX)
 


### PR DESCRIPTION
This is a set of corrections for previous PRs discovered after additional testing.

- Third-party vendors will now only be considered active if at least one source repository from their repomap is present **and enabled.**
  - Previously just being present would be sufficient.
- Leftover packages now correctly exclude unsigned packages.
  - This was a regression from the previous state.
- Configuration files restored in `restore_my_sql_data` actor are wrapped in try/except block with error logging and reporting.