### PR TITLE
Split no-panel and legacy panel detection code

### DIFF
--- a/repos/system_upgrade/cloudlinux/actors/checkpanelmemory/libraries/checkpanelmemory.py
+++ b/repos/system_upgrade/cloudlinux/actors/checkpanelmemory/libraries/checkpanelmemory.py
@@ -4,12 +4,14 @@ from leapp.libraries.stdlib import api
 from leapp.models import MemoryInfo, InstalledControlPanel
 
 from leapp.libraries.common.detectcontrolpanel import (
+    NOPANEL_NAME,
     UNKNOWN_NAME,
     INTEGRATED_NAME,
     CPANEL_NAME,
 )
 
 required_memory = {
+    NOPANEL_NAME: 1536 * 1024,  # 1.5 Gb
     UNKNOWN_NAME: 1536 * 1024,  # 1.5 Gb
     INTEGRATED_NAME: 1536 * 1024,  # 1.5 Gb
     CPANEL_NAME: 2048 * 1024,  # 2 Gb

--- a/repos/system_upgrade/cloudlinux/actors/detectcontrolpanel/actor.py
+++ b/repos/system_upgrade/cloudlinux/actors/detectcontrolpanel/actor.py
@@ -7,6 +7,7 @@ from leapp.exceptions import StopActorExecutionError
 
 from leapp.libraries.common.cllaunch import run_on_cloudlinux
 from leapp.libraries.common.detectcontrolpanel import (
+    NOPANEL_NAME,
     UNKNOWN_NAME,
     INTEGRATED_NAME,
     CPANEL_NAME,
@@ -31,7 +32,7 @@ class DetectControlPanel(Actor):
 
         if panel.name == CPANEL_NAME:
             self.log.debug('cPanel detected, upgrade proceeding')
-        elif panel.name == INTEGRATED_NAME or panel.name == UNKNOWN_NAME:
+        elif panel.name == INTEGRATED_NAME or panel.name == UNKNOWN_NAME or panel.name == NOPANEL_NAME:
             self.log.debug('Integrated/no panel detected, upgrade proceeding')
         elif panel:
             # Block the upgrade on any systems with a non-supported panel detected.

--- a/repos/system_upgrade/cloudlinux/libraries/detectcontrolpanel.py
+++ b/repos/system_upgrade/cloudlinux/libraries/detectcontrolpanel.py
@@ -4,12 +4,13 @@ import os.path
 from leapp.libraries.stdlib import api
 
 
+NOPANEL_NAME = 'No panel'
 CPANEL_NAME = 'cPanel'
 DIRECTADMIN_NAME = 'DirectAdmin'
 PLESK_NAME = 'Plesk'
 ISPMANAGER_NAME = 'ISPManager'
 INTERWORX_NAME = 'InterWorx'
-UNKNOWN_NAME = 'Unknown'
+UNKNOWN_NAME = 'Unknown (legacy)'
 INTEGRATED_NAME = 'Integrated'
 
 CLSYSCONFIG = '/etc/sysconfig/cloudlinux'
@@ -45,7 +46,7 @@ def detect_panel():
     This function will try to detect control panels supported by CloudLinux
     :return: Detected control panel name or None
     """
-    panel_name = None
+    panel_name = NOPANEL_NAME
     if os.path.isfile('/opt/cpvendor/etc/integration.ini'):
         panel_name = INTEGRATED_NAME
     elif os.path.isfile('/usr/local/cpanel/cpanel'):


### PR DESCRIPTION
Previously the web-panel detection code didn't have a dedicated name string for the case where no panel at all was detected. This could potentially introduce errors in other actors that made use of provided data down the line.
The "no panel detected" case is now indicated with a separate string instead of None. 