### PR TITLE
Set major version to releasever dnf variable during upgrade

### DIFF
--- a/repos/system_upgrade/common/actors/checketcreleasever/libraries/checketcreleasever.py
+++ b/repos/system_upgrade/common/actors/checketcreleasever/libraries/checketcreleasever.py
@@ -1,22 +1,21 @@
 from leapp import reporting
 from leapp.models import PkgManagerInfo, RHUIInfo
 from leapp.libraries.stdlib import api
+from leapp.libraries.common.config.version import get_target_major_version
 
 
 def handle_etc_releasever():
 
-    target_version = api.current_actor().configuration.version.target
+    target_version = get_target_major_version()
     reporting.create_report([
         reporting.Title(
-            'Release version in /etc/dnf/vars/releasever will be set to the current target release'
+            'Release version in /etc/dnf/vars/releasever will be set to the major target release'
         ),
         reporting.Summary(
             'On this system, Leapp detected "releasever" variable is either configured through DNF/YUM configuration '
             'file and/or the system is using RHUI infrastructure. In order to avoid issues with repofile URLs '
             '(when --release option is not provided) in cases where there is the previous major.minor version value '
-            'in the configuration, release version will be set to the target release version ({}). This will also '
-            'ensure the system stays on the target version after the upgrade. In order to enable latest minor version '
-            'updates, you can remove "/etc/dnf/vars/releasever" file.'.format(
+            'in the configuration, release version will be set to the major target release version ({}).'.format(
                 target_version
             )
         ),

--- a/repos/system_upgrade/common/actors/setetcreleasever/libraries/setetcreleasever.py
+++ b/repos/system_upgrade/common/actors/setetcreleasever/libraries/setetcreleasever.py
@@ -1,5 +1,6 @@
 from leapp.libraries.stdlib import api
 from leapp.models import PkgManagerInfo, RHUIInfo
+from leapp.libraries.common.config.version import get_target_major_version
 
 
 def _set_releasever(releasever):
@@ -10,7 +11,7 @@ def _set_releasever(releasever):
 
 
 def process():
-    target_version = api.current_actor().configuration.version.target
+    target_version = get_target_major_version()
 
     pkg_facts = next(api.consume(PkgManagerInfo), None)
     rhui_facts = next(api.consume(RHUIInfo), None)


### PR DESCRIPTION
Currently, if `releasever` dnf variable is set (usually to stick to some minor release), leapp with write minor target version during upgrade which is currently 8.6 or 9.0 (even if the latest versions are 8.7 and 9.1).
It's OK for RHEL, but minor versions are not available on repos at least for CentOS Stream and EuroLinux, and EuroLinux even has this dnf variable in el-release package, so setting it to 9.0 breaks system repos and 3rd party repos like EPEL too.
I propose to write major version to releasever dnf variable in case it exists.
I also contacted EuroLinux team to consider removing `releasever` dnf variable from their el-release package.