### PR TITLE
Add CentOS repository keys for aarch64 and PowerPC

### DIFF
--- a/repos/system_upgrade/common/actors/redhatsignedrpmscanner/actor.py
+++ b/repos/system_upgrade/common/actors/redhatsignedrpmscanner/actor.py
@@ -12,7 +12,9 @@ VENDOR_SIGS = {
              '45689c882fa658e0'],
     'centos': ['24c6a8a7f4a80eb5',
                '05b555b38483c65d',
-               '4eb84e71f2ee9d55'],
+               '4eb84e71f2ee9d55',
+               'a963bbdbf533f4fa',
+               '6c7cb6ef305d49d6']
     'cloudlinux': ['8c55a6628608cb71'],
     'almalinux': ['51d6647ec21ad6ea',
                   'd36cb86cb86b3716'],


### PR DESCRIPTION
These are documented here [1] and are needed in order to use leapp on those architectures when upgrading from CentOS 7.

[1] https://www.centos.org/keys/

Signed-off-by: Lance Albertson <lance@osuosl.org>
