### PR TITLE
Fix erroneous syntax with new CentOS keys

### DIFF
--- a/repos/system_upgrade/common/actors/redhatsignedrpmscanner/actor.py
+++ b/repos/system_upgrade/common/actors/redhatsignedrpmscanner/actor.py
@@ -14,7 +14,7 @@ VENDOR_SIGS = {
                '05b555b38483c65d',
                '4eb84e71f2ee9d55',
                'a963bbdbf533f4fa',
-               '6c7cb6ef305d49d6']
+               '6c7cb6ef305d49d6'],
     'cloudlinux': ['8c55a6628608cb71'],
     'almalinux': ['51d6647ec21ad6ea',
                   'd36cb86cb86b3716'],


### PR DESCRIPTION
#66 introduced a syntax error to the `leapp-repository/repos/system_upgrade/common/actors/redhatsignedrpmscanner/actor.py` file, to the section with the list of signatures. As a result, the upgrade process fails to start at the very beginning.

This change fixes the error.