### PR TITLE
Restore package repositories' enabled/disabled states after the upgrade

### DIFF
--- a/repos/system_upgrade/cloudlinux/actors/restorerepositoryconfigurations/actor.py
+++ b/repos/system_upgrade/cloudlinux/actors/restorerepositoryconfigurations/actor.py
@@ -1,0 +1,41 @@
+from leapp.actors import Actor
+from leapp.libraries.stdlib import api
+from leapp.libraries.common import dnfconfig, mounting, repofileutils
+from leapp.models import (
+    RepositoriesFacts,
+)
+from leapp.tags import ApplicationsPhaseTag, IPUWorkflowTag
+
+
+class RestoreRepositoryConfigurations(Actor):
+    """
+    Go over the list of repositories that were present on the pre-upgrade system and compare them to the current list (after the main upgrade transaction).
+    If any of the repositories with same repoIDs have changed their enabled state, due to changes coming from RPM package updates or something else, restore their enabled settings to the pre-upgrade state.
+    """
+
+    name = 'restore_repository_configurations'
+    consumes = (RepositoriesFacts)
+    produces = ()
+    tags = (ApplicationsPhaseTag, IPUWorkflowTag)
+
+    def process(self):
+        current_repofiles = repofileutils.get_parsed_repofiles()
+        current_repository_list = []
+        for repofile in current_repofiles:
+            current_repository_list.extend(repofile.data)
+        current_repodict = dict((repo.repoid, repo) for repo in current_repository_list)
+
+        self.log.debug("Repositories currently present on the system: {}".format(current_repodict.keys()))
+
+        cmd_context = mounting.NotIsolatedActions(base_dir='/')
+
+        for repos_facts in api.consume(RepositoriesFacts):
+            for repo_file in repos_facts.repositories:
+                for repo_data in repo_file.data:
+                    if repo_data.repoid in current_repodict:
+                        if repo_data.enabled and not current_repodict[repo_data.repoid].enabled:
+                            self.log.debug("Repository {} was enabled pre-upgrade, restoring".format(repo_data.repoid))
+                            dnfconfig.enable_repository(cmd_context, repo_data.repoid)
+                        elif not repo_data.enabled and current_repodict[repo_data.repoid].enabled:
+                            self.log.debug("Repository {} was disabled pre-upgrade, restoring".format(repo_data.repoid))
+                            dnfconfig.disable_repository(cmd_context, repo_data.repoid)

--- a/repos/system_upgrade/cloudlinux/actors/restorerepositoryconfigurations/actor.py
+++ b/repos/system_upgrade/cloudlinux/actors/restorerepositoryconfigurations/actor.py
@@ -1,6 +1,7 @@
 from leapp.actors import Actor
 from leapp.libraries.stdlib import api
 from leapp.libraries.common import dnfconfig, mounting, repofileutils
+from leapp.libraries.common.cllaunch import run_on_cloudlinux
 from leapp.models import (
     RepositoriesFacts,
 )
@@ -20,6 +21,7 @@ class RestoreRepositoryConfigurations(Actor):
     produces = ()
     tags = (ApplicationsPhaseTag.After, IPUWorkflowTag)
 
+    @run_on_cloudlinux
     def process(self):
         current_repofiles = repofileutils.get_parsed_repofiles()
         current_repository_list = []

--- a/repos/system_upgrade/cloudlinux/actors/restorerepositoryconfigurations/actor.py
+++ b/repos/system_upgrade/cloudlinux/actors/restorerepositoryconfigurations/actor.py
@@ -25,7 +25,8 @@ class RestoreRepositoryConfigurations(Actor):
             current_repository_list.extend(repofile.data)
         current_repodict = dict((repo.repoid, repo) for repo in current_repository_list)
 
-        self.log.debug("Repositories currently present on the system: {}".format(current_repodict.keys()))
+        current_repoids_string = ", ".join(current_repodict.keys())
+        self.log.debug("Repositories currently present on the system: {}".format(current_repoids_string))
 
         cmd_context = mounting.NotIsolatedActions(base_dir='/')
 

--- a/repos/system_upgrade/cloudlinux/actors/restorerepositoryconfigurations/actor.py
+++ b/repos/system_upgrade/cloudlinux/actors/restorerepositoryconfigurations/actor.py
@@ -9,14 +9,16 @@ from leapp.tags import ApplicationsPhaseTag, IPUWorkflowTag
 
 class RestoreRepositoryConfigurations(Actor):
     """
-    Go over the list of repositories that were present on the pre-upgrade system and compare them to the current list (after the main upgrade transaction).
-    If any of the repositories with same repoIDs have changed their enabled state, due to changes coming from RPM package updates or something else, restore their enabled settings to the pre-upgrade state.
+    Go over the list of repositories that were present on the pre-upgrade system and compare them to the
+    current list (after the main upgrade transaction).
+    If any of the repositories with same repoIDs have changed their enabled state, due to changes coming
+    from RPM package updates or something else, restore their enabled settings to the pre-upgrade state.
     """
 
     name = 'restore_repository_configurations'
     consumes = (RepositoriesFacts)
     produces = ()
-    tags = (ApplicationsPhaseTag, IPUWorkflowTag)
+    tags = (ApplicationsPhaseTag.After, IPUWorkflowTag)
 
     def process(self):
         current_repofiles = repofileutils.get_parsed_repofiles()

--- a/repos/system_upgrade/common/libraries/dnfconfig.py
+++ b/repos/system_upgrade/common/libraries/dnfconfig.py
@@ -124,19 +124,20 @@ def disable_repository(context, reponame):
     _set_repository_state(context, reponame, "disabled")
 
 
-def _set_repository_state(context, reponame, new_state):
+def _set_repository_state(context, repo_id, new_state):
     """
+    Set the Yum repository with the provided ID as enabled or disabled.
     """
     if new_state == "enabled":
         cmd_flag = '--set-enabled'
     elif new_state == "disabled":
         cmd_flag = '--set-disabled'
 
-    cmd = ['dnf', 'config-manager', cmd_flag, reponame]
+    cmd = ['dnf', 'config-manager', cmd_flag, repo_id]
 
     try:
         context.call(cmd)
     except CalledProcessError:
         api.current_logger().error('Cannot set the dnf configuration')
         raise
-    api.current_logger().debug('Repository {} has been {}'.format(reponame, new_state))
+    api.current_logger().debug('Repository {} has been {}'.format(repo_id, new_state))

--- a/repos/system_upgrade/common/libraries/dnfconfig.py
+++ b/repos/system_upgrade/common/libraries/dnfconfig.py
@@ -114,3 +114,29 @@ def exclude_leapp_rpms(context):
     """
     to_exclude = list(set(_get_excluded_pkgs(context) + get_leapp_packages()))
     _set_excluded_pkgs(context, to_exclude)
+
+
+def enable_repository(context, reponame):
+    _set_repository_state(context, reponame, "enabled")
+
+
+def disable_repository(context, reponame):
+    _set_repository_state(context, reponame, "disabled")
+
+
+def _set_repository_state(context, reponame, new_state):
+    """
+    """
+    if new_state == "enabled":
+        cmd_flag = '--set-enabled'
+    elif new_state == "disabled":
+        cmd_flag = '--set-disabled'
+
+    cmd = ['dnf', 'config-manager', cmd_flag, reponame]
+
+    try:
+        context.call(cmd)
+    except CalledProcessError:
+        api.current_logger().error('Cannot set the dnf configuration')
+        raise
+    api.current_logger().debug('Repository {} has been {}'.format(reponame, new_state))


### PR DESCRIPTION
When updating `*-release` packages, Leapp might overwrite settings for repositories that were present on the system - especially ones that are enabled by default.

For example, with CloudLinux, updating the `cloudlinux-release` package will override the settings for `testing` repositories with the most recent package versions. That override is necessary due to changes in URLs, but also preserving the enabled/disabled states of repos would be ideal.

This change introduces a new actor that compares the list of repositories before and after the main upgrade stage, and enables or disables repositories with identical repoids to match the pre-upgrade state.

This also reduces chances of something failing with [cPanel Elevate](https://github.com/cloudlinux/elevate), since it'll perform another package installation after the main one.