### PR TITLE
Repository for WP Toolkit upgrade

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -209,7 +209,7 @@ install-deps:
 	case $(_PYTHON_VENV) in python3*) yum install -y ${shell echo $(_PYTHON_VENV) | tr -d .}; esac
 	@# in centos:7 python dependencies required gcc
 	case $(_PYTHON_VENV) in python3*) yum install gcc -y; esac
-	virtualenv --system-site-packages -p /usr/bin/$(_PYTHON_VENV) $(VENVNAME); \
+	virtualenv -p /usr/bin/$(_PYTHON_VENV) $(VENVNAME); \
 	. $(VENVNAME)/bin/activate; \
 	pip install -U pip; \
 	pip install --upgrade setuptools; \

--- a/repos/system_upgrade/common/libraries/rpms.py
+++ b/repos/system_upgrade/common/libraries/rpms.py
@@ -21,7 +21,10 @@ def get_installed_rpms():
 
 def create_lookup(model, field, keys, context=stdlib.api):
     """
-    Create a lookup set from one of the model fields.
+    Create a lookup list from one of the model fields.
+    Returns a list of keys instead of a set, as you might want to
+    access this data at some point later in some form of structured
+    manner. See package_data_for
 
     :param model: model class
     :param field: model field, its value will be taken for lookup data
@@ -30,20 +33,20 @@ def create_lookup(model, field, keys, context=stdlib.api):
     """
     data = getattr(next((m for m in context.consume(model)), model()), field)
     try:
-        return {tuple(getattr(obj, key) for key in keys) for obj in data} if data else set()
+        return [tuple(getattr(obj, key) for key in keys) for obj in data] if data else list()
     except TypeError:
         # data is not iterable, not lookup can be built
         stdlib.api.current_logger().error(
                 "{model}.{field}.{keys} is not iterable, can't build lookup".format(
                     model=model, field=field, keys=keys))
-        return set()
+        return list()
 
 
 def has_package(model, package_name, arch=None, version=None, release=None, context=stdlib.api):
     """
     Expects a model InstalledRedHatSignedRPM or InstalledUnsignedRPM.
     Can be useful in cases like a quick item presence check, ex. check in actor that
-    a certain package is installed.
+    a certain package is installed. Returns BOOL
     :param model: model class
     :param package_name: package to be checked
     :param arch: filter by architecture. None means all arches.
@@ -59,8 +62,28 @@ def has_package(model, package_name, arch=None, version=None, release=None, cont
         keys.append('version')
     if release:
         keys.append('release')
-
     attributes = [package_name]
     attributes += [attr for attr in (arch, version, release) if attr is not None]
     rpm_lookup = create_lookup(model, field='items', keys=keys, context=context)
     return tuple(attributes) in rpm_lookup
+
+
+def package_data_for(model, package_name, package_arch=None, package_version=None, package_release=None, context=stdlib.api):
+    """
+    Expects a model InstalledRedHatSignedRPM or InstalledUnsignedRPM.
+    Useful for where we want to know a thing is installed
+    THEN do something based on the data.
+    Returns list( name, arch, version, release ) for given RPM.
+    :param model: model class
+    :param package_name: package to be checked
+    :param arch: filter by architecture. None means all arches.
+    :param version: filter by version. None means all versions.
+    :param release: filter by release. None means all releases.
+    """
+    if not (isinstance(model, type) and issubclass(model, InstalledRPM)):
+        return list()
+
+    lookup_keys = ['name', 'arch', 'version', 'release']
+    rpm_lookup = create_lookup(model, field='items', keys=lookup_keys, context=context)
+
+    return [(name, arch, version, release) for (name, arch, version, release) in rpm_lookup if ( (name == package_name) and (package_arch is None or arch == package_arch) and (package_version is None or version == package_version) and (package_release is None or release == package_release))]

--- a/repos/system_upgrade/wp-toolkit/.leapp/info
+++ b/repos/system_upgrade/wp-toolkit/.leapp/info
@@ -1,0 +1,1 @@
+{"name": "wp-toolkit", "id": "ae31666a-37b8-435c-a071-a3d28342099b", "repos": ["644900a5-c347-43a3-bfab-f448f46d9647"]}

--- a/repos/system_upgrade/wp-toolkit/.leapp/leapp.conf
+++ b/repos/system_upgrade/wp-toolkit/.leapp/leapp.conf
@@ -1,0 +1,6 @@
+
+[repositories]
+repo_path=${repository:root_dir}
+
+[database]
+path=${repository:state_dir}/leapp.db

--- a/repos/system_upgrade/wp-toolkit/actors/setwptoolkityumvariable/actor.py
+++ b/repos/system_upgrade/wp-toolkit/actors/setwptoolkityumvariable/actor.py
@@ -1,0 +1,65 @@
+from leapp.actors import Actor
+from leapp.models import ActiveVendorList, CopyFile, TargetUserSpacePreupgradeTasks, WpToolkit
+from leapp.libraries.stdlib import api
+from leapp.tags import TargetTransactionFactsPhaseTag, IPUWorkflowTag
+
+VENDOR_NAME = 'wp-toolkit'
+SUPPORTED_VARIANTS = ['cpanel', ]
+
+# Is the vendors.d path the best place to create this file?
+src_path = '/etc/leapp/files/vendors.d/wp-toolkit.var'
+dst_path = '/etc/dnf/vars/wptkversion'
+
+
+class SetWpToolkitYumVariable(Actor):
+    """
+    Records the current WP Toolkit version into a DNF variable file so that the
+    precise version requested is reinstalled, and forwards the request to copy
+    this data into the upgrading environment using a
+    :class:`TargetUserSpacePreupgradeTasks`.
+    """
+
+    name = 'set_wp_toolkit_yum_variable'
+    consumes = (ActiveVendorList, WpToolkit)
+    produces = (TargetUserSpacePreupgradeTasks,)
+    tags = (TargetTransactionFactsPhaseTag.Before, IPUWorkflowTag)
+
+    def _do_cpanel(self, version):
+
+        files_to_copy = []
+        if version is None:
+            version = 'latest'
+
+        try:
+            with open(src_path, 'w') as var_file:
+                var_file.write(version)
+
+            files_to_copy.append(CopyFile(src=src_path, dst=dst_path))
+            msg = 'Requesting leapp to copy {} into the upgrade environment as {}'.format(src_path, dst_path)
+            api.current_logger().debug(msg)
+
+        except OSError as e:
+            api.current_logger().error('Cannot write to {}: {}'.format(e.filename, e.strerror))
+
+        return TargetUserSpacePreupgradeTasks(copy_files=files_to_copy)
+
+    def process(self):
+
+        active_vendors = []
+        for vendor_list in api.consume(ActiveVendorList):
+            active_vendors.extend(vendor_list.data)
+
+        if VENDOR_NAME in active_vendors:
+            wptk_data = next(api.consume(WpToolkit), WpToolkit())
+
+            preupgrade_task = None
+            if wptk_data.variant == 'cpanel':
+                preupgrade_task = self._do_cpanel(wptk_data.version)
+            else:
+                api.current_logger().warn('Could not recognize a supported environment for WP Toolkit.')
+
+            if preupgrade_task is not None:
+                api.produce(preupgrade_task)
+
+        else:
+            api.current_logger().info('{} not an active vendor: skipping actor'.format(VENDOR_NAME))

--- a/repos/system_upgrade/wp-toolkit/actors/updatewptoolkitrepos/actor.py
+++ b/repos/system_upgrade/wp-toolkit/actors/updatewptoolkitrepos/actor.py
@@ -1,0 +1,49 @@
+import os
+import shutil
+
+from leapp.actors import Actor
+from leapp.libraries.stdlib import api, run
+from leapp.models import ActiveVendorList, WpToolkit
+from leapp.tags import IPUWorkflowTag, FirstBootPhaseTag
+
+VENDOR_NAME = 'wp-toolkit'
+
+VENDORS_DIR = '/etc/leapp/files/vendors.d'
+REPO_DIR = '/etc/yum.repos.d'
+
+class UpdateWpToolkitRepos(Actor):
+    """
+    Replaces the WP Toolkit's old repo file from the CentOS 7 version with one appropriate for the new OS.
+    """
+
+    name = 'update_wp_toolkit_repos'
+    consumes = (ActiveVendorList, WpToolkit)
+    produces = ()
+    tags = (IPUWorkflowTag, FirstBootPhaseTag)
+
+    def process(self):
+
+        active_vendors = []
+        for vendor_list in api.consume(ActiveVendorList):
+            active_vendors.extend(vendor_list.data)
+
+        if VENDOR_NAME in active_vendors:
+
+            wptk_data = next(api.consume(WpToolkit), WpToolkit())
+
+            src_file = api.get_file_path('{}-{}.el8.repo'. format(VENDOR_NAME, wptk_data.variant))
+            dst_file = '{}/{}-{}.repo'.format(REPO_DIR, VENDOR_NAME, wptk_data.variant)
+
+            try:
+                os.rename(dst_file, dst_file + '.bak')
+            except OSError as e:
+                api.current_logger().warn('Could not rename {} to {}: {}'.format(e.filename, e.filename2, e.strerror))
+
+            api.current_logger().info('Updating WPTK package repository file at {} using {}'.format(dst_file, src_file))
+
+            try:
+                shutil.copy(src_file, dst_file)
+            except OSError as e:
+                api.current_logger().error('Could not update WPTK package repository file {}: {}'.format(e.filename2, e.strerror))
+        else:
+            api.current_logger().info('{} not an active vendor: skipping actor'.format(VENDOR_NAME))

--- a/repos/system_upgrade/wp-toolkit/actors/wptoolkitfacts/actor.py
+++ b/repos/system_upgrade/wp-toolkit/actors/wptoolkitfacts/actor.py
@@ -1,10 +1,12 @@
 from leapp.actors import Actor
-from leapp.libraries.stdlib import api, run
-from leapp.models import ActiveVendorList, WpToolkit, VendorSourceRepos
+from leapp.libraries.stdlib import api
+from leapp.models import ActiveVendorList, WpToolkit, VendorSourceRepos, InstalledRPM
 from leapp.tags import IPUWorkflowTag, FactsPhaseTag
+from leapp.libraries.common.rpms import package_data_for
 
 VENDOR_NAME = 'wp-toolkit'
-SUPPORTED_VARIANTS = ['cpanel',]
+SUPPORTED_VARIANTS = ['cpanel', ]
+
 
 class WpToolkitFacts(Actor):
     """
@@ -12,7 +14,7 @@ class WpToolkitFacts(Actor):
     """
 
     name = 'wp_toolkit_facts'
-    consumes = (ActiveVendorList, VendorSourceRepos)
+    consumes = (ActiveVendorList, VendorSourceRepos, InstalledRPM)
     produces = (WpToolkit,)
     tags = (IPUWorkflowTag, FactsPhaseTag)
 
@@ -38,12 +40,10 @@ class WpToolkitFacts(Actor):
                     variant = maybe_variant
                     api.current_logger().info('Found WP Toolkit variant {}'.format(variant))
 
-                    try:
-                        result = run(['/usr/bin/rpm', '-q', '--queryformat=%{VERSION}', '{}-{}'.format(VENDOR_NAME, variant)])
-                        version = result['stdout']
-                        api.current_logger().info('Found WP Toolkit version {}'.format(version))
-                    except:
-                        api.current_logger().info('No WP Toolkit package appears to be installed.')
+                    pkgData = package_data_for(InstalledRPM, 'wp-toolkit-{}'.format(variant))
+                    # name, arch, version, release
+                    if pkgData:
+                        version = pkgData[0][2]
 
                     break
 

--- a/repos/system_upgrade/wp-toolkit/actors/wptoolkitfacts/actor.py
+++ b/repos/system_upgrade/wp-toolkit/actors/wptoolkitfacts/actor.py
@@ -1,0 +1,55 @@
+from leapp.actors import Actor
+from leapp.libraries.stdlib import api, run
+from leapp.models import ActiveVendorList, WpToolkit, VendorSourceRepos
+from leapp.tags import IPUWorkflowTag, FactsPhaseTag
+
+VENDOR_NAME = 'wp-toolkit'
+SUPPORTED_VARIANTS = ['cpanel',]
+
+class WpToolkitFacts(Actor):
+    """
+    Find out whether a supported WP Toolkit repository is present and whether the appropriate package is installed.
+    """
+
+    name = 'wp_toolkit_facts'
+    consumes = (ActiveVendorList, VendorSourceRepos)
+    produces = (WpToolkit,)
+    tags = (IPUWorkflowTag, FactsPhaseTag)
+
+    def process(self):
+
+        active_vendors = []
+        for vendor_list in api.consume(ActiveVendorList):
+            active_vendors.extend(vendor_list.data)
+
+        if VENDOR_NAME in active_vendors:
+            api.current_logger().info('Vendor {} is active. Looking for information...'.format(VENDOR_NAME))
+
+            repo_list = []
+            for src_info in api.consume(VendorSourceRepos):
+                if src_info.vendor == VENDOR_NAME:
+                    repo_list = src_info.source_repoids
+                    break
+
+            variant = None
+            version = None
+            for maybe_variant in SUPPORTED_VARIANTS:
+                if '{}-{}'.format(VENDOR_NAME, maybe_variant) in repo_list:
+                    variant = maybe_variant
+                    api.current_logger().info('Found WP Toolkit variant {}'.format(variant))
+
+                    try:
+                        result = run(['/usr/bin/rpm', '-q', '--queryformat=%{VERSION}', '{}-{}'.format(VENDOR_NAME, variant)])
+                        version = result['stdout']
+                        api.current_logger().info('Found WP Toolkit version {}'.format(version))
+                    except:
+                        api.current_logger().info('No WP Toolkit package appears to be installed.')
+
+                    break
+
+                api.current_logger().debug('Did not find WP Toolkit variant {}'.format(maybe_variant))
+
+            api.produce(WpToolkit(variant=variant, version=version))
+
+        else:
+            api.current_logger().info('{} not an active vendor: skipping actor'.format(VENDOR_NAME))

--- a/repos/system_upgrade/wp-toolkit/actors/wptoolkitfacts/tests/test_wptoolkitfacts.py
+++ b/repos/system_upgrade/wp-toolkit/actors/wptoolkitfacts/tests/test_wptoolkitfacts.py
@@ -1,0 +1,38 @@
+# XXX TODO this copies a lot from satellite_upgrade_facts.py, should probably make a fixture
+# for fake_package at the least?
+
+from leapp.models import InstalledRPM, RPM, ActiveVendorList, VendorSourceRepos, WpToolkit
+
+RH_PACKAGER = 'Red Hat, Inc. <http://bugzilla.redhat.com/bugzilla>'
+
+
+def fake_package(pkg_name,version):
+    return RPM(name=pkg_name, version=version, release='1.sm01', epoch='1', packager=RH_PACKAGER, arch='noarch',
+               pgpsig='RSA/SHA256, Mon 01 Jan 1970 00:00:00 AM -03, Key ID 199e2f91fd431d51')
+
+
+BOGUS_RPM = fake_package('bogus-bogus', '1.0')
+WPTOOLKIT_RPM = fake_package('wp-toolkit-cpanel', '0.1')
+
+
+def test_no_wptoolkit_vendor_present(current_actor_context):
+    current_actor_context.feed(ActiveVendorList(data=list(["jello"])), InstalledRPM(items=[]))
+    current_actor_context.run()
+    message = current_actor_context.consume(WpToolkit)
+    assert not message
+
+
+def test_no_wptoolkit_rpm_present(current_actor_context):
+    current_actor_context.feed(ActiveVendorList(data=list(['wp-toolkit'])), InstalledRPM(items=[]))
+    current_actor_context.run()
+    message = current_actor_context.consume(WpToolkit)
+    assert not hasattr(message, 'variant')
+    assert not hasattr(message, 'version')
+
+
+def test_wptoolkit_rpm_present(current_actor_context):
+    current_actor_context.feed(ActiveVendorList(data=list(['wp-toolkit'])), VendorSourceRepos(vendor='wp-toolkit',source_repoids=list(['wp-toolkit-cpanel'])), InstalledRPM(items=[BOGUS_RPM,WPTOOLKIT_RPM]))
+    current_actor_context.run()
+    message = current_actor_context.consume(WpToolkit)[0]
+    assert message.variant == 'cpanel'
+    assert message.version == '0.1'

--- a/repos/system_upgrade/wp-toolkit/files/wp-toolkit-cpanel.el8.repo
+++ b/repos/system_upgrade/wp-toolkit/files/wp-toolkit-cpanel.el8.repo
@@ -1,0 +1,11 @@
+[wp-toolkit-cpanel]
+name=WP Toolkit for cPanel
+baseurl=https://wp-toolkit.plesk.com/cPanel/CentOS-8-x86_64/latest/wp-toolkit/
+enabled=1
+gpgcheck=1
+
+[wp-toolkit-thirdparties]
+name=WP Toolkit third parties
+baseurl=https://wp-toolkit.plesk.com/cPanel/CentOS-8-x86_64/latest/thirdparty/
+enabled=1
+gpgcheck=1

--- a/repos/system_upgrade/wp-toolkit/models/wptoolkit.py
+++ b/repos/system_upgrade/wp-toolkit/models/wptoolkit.py
@@ -1,0 +1,23 @@
+from leapp.models import Model, fields
+from leapp.topics import SystemFactsTopic
+
+
+class WpToolkit(Model):
+    """
+    Records information about presence and versioning of WP Toolkit package management resources on the source system.
+    """
+    topic = SystemFactsTopic
+
+    """
+    States which supported "variant" of WP Toolkit seems available to the package manager.
+
+    Currently, only `cpanel` is supported.
+    """
+    variant = fields.Nullable(fields.String())
+
+    """
+    States which version of the WP Toolkit package for the given variant is installed.
+
+    If no package is installed, this will be `None`.
+    """
+    version = fields.Nullable(fields.String())


### PR DESCRIPTION
The purpose of this pull request is to provide actors (along with a model and a file) to assist the `wp-toolkit` vendor, which is being concurrently submitted as Almalinux/leapp-data#22, in upgrading installations of the WP Toolkit. The code is written in such a way that, if or when a standalone variant of WP Toolkit is made available, such installations can be supported with minimal changes.