### PR TITLE
Add optional Sentry logging for actor errors and upgrade inhibitors

### DIFF
--- a/commands/preupgrade/__init__.py
+++ b/commands/preupgrade/__init__.py
@@ -48,6 +48,16 @@ def preupgrade(args, breadcrumbs):
     logger = configure_logger('leapp-preupgrade.log')
     os.environ['LEAPP_EXECUTION_ID'] = context
 
+    sentry_client = None
+    sentry_dsn = cfg.get('sentry', 'dsn')
+    if sentry_dsn:
+        try:
+            from raven import Client
+            from raven.transport.http import HTTPTransport
+            sentry_client = Client(sentry_dsn, transport=HTTPTransport)
+        except ImportError:
+            logger.warn("Cannot import the Raven library - remote error logging not functional")
+
     try:
         repositories = util.load_repositories()
     except LeappError as exc:
@@ -56,7 +66,8 @@ def preupgrade(args, breadcrumbs):
     workflow = repositories.lookup_workflow('IPUWorkflow')()
     util.warn_if_unsupported(configuration)
     util.process_whitelist_experimental(repositories, workflow, configuration, logger)
-    with beautify_actor_exception():
+
+    with util.format_actor_exceptions(logger, sentry_client):
         workflow.load_answers(answerfile_path, userchoices_path)
         until_phase = 'ReportsPhase'
         logger.info('Executing workflow until phase: %s', until_phase)
@@ -68,12 +79,17 @@ def preupgrade(args, breadcrumbs):
 
     logger.info("Answerfile will be created at %s", answerfile_path)
     workflow.save_answers(answerfile_path, userchoices_path)
-    util.generate_report_files(context, report_schema)
+
+    util.log_errors(workflow.errors, logger)
+    util.log_inhibitors(context, logger, sentry_client)
     report_errors(workflow.errors)
     report_inhibitors(context)
+
+    util.generate_report_files(context, report_schema)
     report_files = util.get_cfg_files('report', cfg)
     log_files = util.get_cfg_files('logs', cfg)
     report_info(report_files, log_files, answerfile_path, fail=workflow.failure)
+
     if workflow.failure:
         sys.exit(1)
 

--- a/commands/upgrade/__init__.py
+++ b/commands/upgrade/__init__.py
@@ -9,7 +9,7 @@ from leapp.exceptions import CommandError, LeappError
 from leapp.logger import configure_logger
 from leapp.utils.audit import Execution
 from leapp.utils.clicmd import command, command_opt
-from leapp.utils.output import beautify_actor_exception, report_errors, report_info, report_inhibitors
+from leapp.utils.output import report_errors, report_info, report_inhibitors
 
 # NOTE:
 # If you are adding new parameters please ensure that they are set in the upgrade function invocation in `rerun`
@@ -115,10 +115,12 @@ def upgrade(args, breadcrumbs):
 
     logger.info("Answerfile will be created at %s", answerfile_path)
     workflow.save_answers(answerfile_path, userchoices_path)
+
     util.log_errors(workflow.errors, logger)
     util.log_inhibitors(context, logger, sentry_client)
     report_errors(workflow.errors)
     report_inhibitors(context)
+
     util.generate_report_files(context, report_schema)
     report_files = util.get_cfg_files('report', cfg)
     log_files = util.get_cfg_files('logs', cfg)

--- a/commands/upgrade/__init__.py
+++ b/commands/upgrade/__init__.py
@@ -101,7 +101,7 @@ def upgrade(args, breadcrumbs):
             logger.info("Upgrade cancelled by user")
             sys.exit(1)
 
-    with util.format_actor_exceptions(logger):
+    with util.format_actor_exceptions(logger, sentry_client):
         logger.info("Using answerfile at %s", answerfile_path)
         workflow.load_answers(answerfile_path, userchoices_path)
 
@@ -109,7 +109,7 @@ def upgrade(args, breadcrumbs):
         os.environ['LC_ALL'] = 'en_US.UTF-8'
         os.environ['LANG'] = 'en_US.UTF-8'
         workflow.run(context=context, skip_phases_until=skip_phases_until, skip_dialogs=True,
-                     only_with_tags=only_with_tags, sentry_client=sentry_client)
+                     only_with_tags=only_with_tags)
 
     logger.info("Answerfile will be created at %s", answerfile_path)
     workflow.save_answers(answerfile_path, userchoices_path)

--- a/commands/upgrade/__init__.py
+++ b/commands/upgrade/__init__.py
@@ -117,7 +117,7 @@ def upgrade(args, breadcrumbs):
     logger.info("Answerfile will be created at %s", answerfile_path)
     workflow.save_answers(answerfile_path, userchoices_path)
     util.log_errors(workflow.errors, logger)
-    util.log_inhibitors(context, logger)
+    util.log_inhibitors(context, logger, sentry_client)
     report_errors(workflow.errors)
     report_inhibitors(context)
     util.generate_report_files(context, report_schema)

--- a/commands/upgrade/__init__.py
+++ b/commands/upgrade/__init__.py
@@ -2,8 +2,6 @@ import os
 import sys
 import uuid
 
-from raven import Client
-from raven.transport.http import HTTPTransport
 
 from leapp.cli.commands import command_utils
 from leapp.cli.commands.config import get_config
@@ -84,7 +82,12 @@ def upgrade(args, breadcrumbs):
     sentry_client = None
     sentry_dsn = cfg.get('sentry', 'dsn')
     if sentry_dsn:
-        sentry_client = Client(sentry_dsn, transport=HTTPTransport)
+        try:
+            from raven import Client
+            from raven.transport.http import HTTPTransport
+            sentry_client = Client(sentry_dsn, transport=HTTPTransport)
+        except ImportError:
+            logger.warn("Cannot import the Raven library - remote error logging not functional")
 
     if args.resume:
         logger.info("Resuming execution after phase: %s", skip_phases_until)

--- a/commands/upgrade/__init__.py
+++ b/commands/upgrade/__init__.py
@@ -2,7 +2,6 @@ import os
 import sys
 import uuid
 
-
 from leapp.cli.commands import command_utils
 from leapp.cli.commands.config import get_config
 from leapp.cli.commands.upgrade import breadcrumbs, util

--- a/commands/upgrade/util.py
+++ b/commands/upgrade/util.py
@@ -21,8 +21,6 @@ from leapp.utils.report import fetch_upgrade_report_messages, generate_report_fi
 from leapp.models import ErrorModel
 
 
-
-
 def disable_database_sync():
     def disable_db_sync_decorator(f):
         @functools.wraps(f)
@@ -345,8 +343,12 @@ def log_inhibitors(context_id, logger, sentry):
         if sentry:
             for inhibitor in inhibitors:
                 sentry.captureMessage(
-                    f"Inhibitor: {inhibitor['title']}\n"
-                    f"Severity: {inhibitor['severity']}\n"
-                    f"{inhibitor['summary']}"
+                    "Inhibitor: {}\n"
+                    "Severity: {}\n"
+                    "{}".format(
+                        inhibitor['title'],
+                        inhibitor['severity'],
+                        inhibitor['summary']
+                    )
                 )
 

--- a/commands/upgrade/util.py
+++ b/commands/upgrade/util.py
@@ -300,9 +300,9 @@ def format_actor_exceptions(logger, sentry):
             sys.stderr.write("\n")
             sys.stderr.write(pretty_block_text(msg, color="", width=len(msg)))
             logger.error(err.message)
-            logger.error(err.exception_info)
             if sentry:
-                sentry.captureException(extra={"exception_info": err.exception_info})
+                sent_code = sentry.captureException()
+                logger.info("Error \"{}\" sent to Sentry with code {}".format(err, sent_code))
     finally:
         pass
 
@@ -351,4 +351,4 @@ def log_inhibitors(context_id, logger, sentry):
                         inhibitor['summary']
                     )
                 )
-
+                logger.info("Inhibitor \"{}\" sent to Sentry".format(inhibitor['title']))

--- a/commands/upgrade/util.py
+++ b/commands/upgrade/util.py
@@ -293,20 +293,18 @@ def pretty_block_log(string, logger_level, width=60):
 
 
 @contextmanager
-def format_actor_exceptions(logger):
+def format_actor_exceptions(logger, sentry):
     try:
         try:
             yield
         except LeappRuntimeError as e:
-            # TODO: This only reports the actor that raised an exception
-            # and the return code.
-            # The traceback gets eaten on the framework level, and is only
-            # seen in stderr. Changing that will require modifying the framework
-            # code itself.
             msg = '{} - Please check the above details'.format(e.message)
             sys.stderr.write("\n")
             sys.stderr.write(pretty_block_text(msg, color="", width=len(msg)))
             logger.error(e.message)
+            logger.error(e.exception_info)
+            if sentry:
+                sentry.captureMessage("{}\n{}".format(e.message, e.exception_info))
     finally:
         pass
 

--- a/commands/upgrade/util.py
+++ b/commands/upgrade/util.py
@@ -297,14 +297,14 @@ def format_actor_exceptions(logger, sentry):
     try:
         try:
             yield
-        except LeappRuntimeError as e:
-            msg = '{} - Please check the above details'.format(e.message)
+        except LeappRuntimeError as err:
+            msg = '{} - Please check the above details'.format(err.message)
             sys.stderr.write("\n")
             sys.stderr.write(pretty_block_text(msg, color="", width=len(msg)))
-            logger.error(e.message)
-            logger.error(e.exception_info)
+            logger.error(err.message)
+            logger.error(err.exception_info)
             if sentry:
-                sentry.captureMessage("{}\n{}".format(e.message, e.exception_info))
+                sentry.captureMessage(f"{err.message}\n{err.exception_info}")
     finally:
         pass
 

--- a/commands/upgrade/util.py
+++ b/commands/upgrade/util.py
@@ -298,7 +298,7 @@ def format_actor_exceptions(logger, sentry):
         try:
             yield
         except LeappRuntimeError as err:
-            msg = '{} - Please check the above details'.format(err.message)
+            msg = f'{err.message} - Please check the above details'
             sys.stderr.write("\n")
             sys.stderr.write(pretty_block_text(msg, color="", width=len(msg)))
             logger.error(err.message)

--- a/packaging/leapp-repository.spec
+++ b/packaging/leapp-repository.spec
@@ -137,6 +137,8 @@ Requires:   pciutils
 # Required to gather system facts about SELinux
 Requires:   libselinux-python
 Requires:   python-pyudev
+# Required to gather data about actor exceptions or inhibitors
+Requires:   python-raven
 # required by SELinux actors
 Requires:   policycoreutils-python
 # Required to fetch leapp data
@@ -147,6 +149,8 @@ Requires:   python-requests
 # systemd-nspawn utility
 Requires:   systemd-container
 Requires:   python3-pyudev
+# Required to gather data about actor exceptions or inhibitors
+Requires:   python3-raven
 # Required to fetch leapp data
 Requires:   python3-requests
 # Required because the code is kept Py2 & Py3 compatible

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,5 +11,6 @@ distro==1.5.0
 ipaddress==1.0.23
 git+https://github.com/oamg/leapp
 requests
+raven
 # pinning a py27 troublemaking transitive dependency
 lazy-object-proxy==1.5.2; python_version < '3'


### PR DESCRIPTION
This change allows the user to specify a [Sentry](https://sentry.io) URL in a new section of the `leapp.conf` configuration file in order to send information about occurring errors to the specified destination.

If one is not provided, information is not sent anywhere.