### PR TITLE
Use all rollout repositories from a file that is taken for the upgrade

### DIFF
--- a/repos/system_upgrade/cloudlinux/actors/scanrolloutrepositories/libraries/scanrolloutrepositories.py
+++ b/repos/system_upgrade/cloudlinux/actors/scanrolloutrepositories/libraries/scanrolloutrepositories.py
@@ -36,14 +36,11 @@ def process():
             api.current_logger().debug("Rollout file {} has used repositories, adding".format(reponame))
 
         for repo in repofile.data:
-            # Don't enable all the rollout repositories wholesale, some might
-            # be disabled and we want to keep that configuration.
-            if repo.enabled:
-                api.produce(CustomTargetRepository(
-                    repoid=repo.repoid,
-                    name=repo.name,
-                    baseurl=repo.baseurl,
-                    enabled=repo.enabled,
-                ))
+            api.produce(CustomTargetRepository(
+                repoid=repo.repoid,
+                name=repo.name,
+                baseurl=repo.baseurl,
+                enabled=repo.enabled,
+            ))
 
         api.produce(CustomTargetRepositoryFile(file=full_repo_path))

--- a/repos/system_upgrade/common/actors/setuptargetrepos/libraries/setuptargetrepos.py
+++ b/repos/system_upgrade/common/actors/setuptargetrepos/libraries/setuptargetrepos.py
@@ -152,11 +152,12 @@ def process():
     # initialise basic data
     repomap = _setup_repomap_handler(enabled_repoids, mapping_list)
     mapped_repoids = _get_mapped_repoids(repomap, enabled_repoids)
+    api.current_logger().debug('Mapped repos: {}'.format(mapped_repoids))
     skipped_repoids = enabled_repoids & set(used_repoids_dict.keys()) - mapped_repoids
 
     # Now get the info what should be the target RHEL repositories
     expected_repos = repomap.get_expected_target_pesid_repos(enabled_repoids)
-    api.current_logger().debug('Expected repos: {}'.format(expected_repos))
+    api.current_logger().debug('Expected repos: {}'.format(expected_repos.keys()))
     target_rhel_repoids = set()
     for target_pesid, target_pesidrepo in expected_repos.items():
         if not target_pesidrepo:


### PR DESCRIPTION
If some are skipped, it can introduce a failstate situation where the later stages of leapp upgrade cannot resolve the repoid mentioned in the rollout repository config file.