### PR TITLE
Replace f-string with format to restore py2 compatibility

### DIFF
--- a/commands/upgrade/util.py
+++ b/commands/upgrade/util.py
@@ -296,7 +296,7 @@ def format_actor_exceptions(logger, sentry):
         try:
             yield
         except LeappRuntimeError as err:
-            msg = f'{err.message} - Please check the above details'
+            msg = "{} - Please check the above details".format(err.message)
             sys.stderr.write("\n")
             sys.stderr.write(pretty_block_text(msg, color="", width=len(msg)))
             logger.error(err.message)


### PR DESCRIPTION
#73 had a modification that rendered the code non-py2 compatible. Compatibility restored here.