### PR TITLE
Use leapp.conf in etc/leapp/files by default

### DIFF
--- a/commands/config.py
+++ b/commands/config.py
@@ -1,7 +1,9 @@
+import os
 from leapp import config
 
 
 def get_config():
     if not config._LEAPP_CONFIG:
+        os.environ['LEAPP_CONFIG'] = '/etc/leapp/files/leapp.conf'
         config._CONFIG_DEFAULTS['repositories'] = {'repo_path': '/etc/leapp/repos.d'}
     return config.get_config()

--- a/commands/preupgrade/__init__.py
+++ b/commands/preupgrade/__init__.py
@@ -1,6 +1,7 @@
 import os
 import sys
 import uuid
+from six.moves import configparser
 
 from leapp.cli.commands import command_utils
 from leapp.cli.commands.config import get_config
@@ -49,14 +50,17 @@ def preupgrade(args, breadcrumbs):
     os.environ['LEAPP_EXECUTION_ID'] = context
 
     sentry_client = None
-    sentry_dsn = cfg.get('sentry', 'dsn')
-    if sentry_dsn:
-        try:
-            from raven import Client
-            from raven.transport.http import HTTPTransport
-            sentry_client = Client(sentry_dsn, transport=HTTPTransport)
-        except ImportError:
-            logger.warn("Cannot import the Raven library - remote error logging not functional")
+    try:
+        sentry_dsn = cfg.get('sentry', 'dsn')
+        if sentry_dsn:
+            try:
+                from raven import Client
+                from raven.transport.http import HTTPTransport
+                sentry_client = Client(sentry_dsn, transport=HTTPTransport)
+            except ImportError:
+                logger.warn("Cannot import the Raven library - remote error logging not functional")
+    except (configparser.NoSectionError, configparser.NoSectionError) as err:
+        logger.info("Sentry configuration not found due to '{}' - continuing without".format(err))
 
     try:
         repositories = util.load_repositories()

--- a/commands/upgrade/__init__.py
+++ b/commands/upgrade/__init__.py
@@ -1,6 +1,7 @@
 import os
 import sys
 import uuid
+from six.moves import configparser
 
 from leapp.cli.commands import command_utils
 from leapp.cli.commands.config import get_config
@@ -79,14 +80,17 @@ def upgrade(args, breadcrumbs):
     os.environ['LEAPP_EXECUTION_ID'] = context
 
     sentry_client = None
-    sentry_dsn = cfg.get('sentry', 'dsn')
-    if sentry_dsn:
-        try:
-            from raven import Client
-            from raven.transport.http import HTTPTransport
-            sentry_client = Client(sentry_dsn, transport=HTTPTransport)
-        except ImportError:
-            logger.warn("Cannot import the Raven library - remote error logging not functional")
+    try:
+        sentry_dsn = cfg.get('sentry', 'dsn')
+        if sentry_dsn:
+            try:
+                from raven import Client
+                from raven.transport.http import HTTPTransport
+                sentry_client = Client(sentry_dsn, transport=HTTPTransport)
+            except ImportError:
+                logger.warn("Cannot import the Raven library - remote error logging not functional")
+    except (configparser.NoSectionError, configparser.NoSectionError) as err:
+        logger.info("Sentry configuration not found due to '{}' - continuing without".format(err))
 
     if args.resume:
         logger.info("Resuming execution after phase: %s", skip_phases_until)

--- a/commands/upgrade/util.py
+++ b/commands/upgrade/util.py
@@ -296,7 +296,7 @@ def format_actor_exceptions(logger, sentry):
         try:
             yield
         except LeappRuntimeError as err:
-            msg = f'{err.message} - Please check the above details'
+            msg = "{} - Please check the above details".format(err.message)
             sys.stderr.write("\n")
             sys.stderr.write(pretty_block_text(msg, color="", width=len(msg)))
             logger.error(err.message)

--- a/repos/system_upgrade/common/actors/redhatsignedrpmscanner/actor.py
+++ b/repos/system_upgrade/common/actors/redhatsignedrpmscanner/actor.py
@@ -41,7 +41,7 @@ VENDOR_PACKAGERS = {
 
 
 class VendorSignedRpmScanner(Actor):
-    """Provide data about installed RPM Packages signed by Red Hat.
+    """Provide data about installed RPM Packages signed by known packagers.
 
     After filtering the list of installed RPM packages by signature, a message
     with relevant data will be produced.


### PR DESCRIPTION
In order to avoid touching or conflicting with the etc/leapp/leapp.conf brought by the main leapp package, move the per-distro config file to etc/leapp/files (in https://github.com/AlmaLinux/leapp-data/pull/24), and use it by default in preupgrade and upgrade runs.