### PR TITLE
Relax check_panel_memory actor's check

### DIFF
--- a/repos/system_upgrade/cloudlinux/actors/checkpanelmemory/libraries/checkpanelmemory.py
+++ b/repos/system_upgrade/cloudlinux/actors/checkpanelmemory/libraries/checkpanelmemory.py
@@ -17,12 +17,20 @@ required_memory = {
     CPANEL_NAME: 2048 * 1024,  # 2 Gb
 }
 
+# The kernel subtracts memory pages used for its own overhead from the total
+# memory reported to userspace. The subtracted amount varies depending on a
+# variety of factors, but based on a few samples, it seems to use somewhere
+# between 50-75 MiB on a 2 GiB machine, not counting memory reserved for the
+# crash kernel.  Allow for a little more than this to be missing from the total
+# before this check is considered a failure.
+ALLOWABLE_OVERHEAD = 96 * 1024  # 96 MiB
+
 
 def _check_memory(panel, mem_info):
     msg = {}
 
     min_req = required_memory[panel]
-    is_ok = mem_info.mem_total >= min_req
+    is_ok = mem_info.mem_total >= min_req - ALLOWABLE_OVERHEAD
     msg = {} if is_ok else {"detected": mem_info.mem_total, "minimal_req": min_req}
 
     return msg


### PR DESCRIPTION
The `check_panel_memory` actor is intended to inhibit upgrades when the system lacks the memory needed to satisfy minimum system requirements for CloudLinux 8, which may vary depending on whether a control panel is installed. However, the actor is using the value for total memory as reported by the kernel, rather than the nominal amount of memory actually installed on the system. Since the kernel subtracts its own memory usage from this total, a nominally minimum-spec machine will always fail this check, something which does not appear to be intended. To address this, credit the machine with a certain amount of additional memory when performing the check. (This credited amount will not appear in the message if the check still fails.)

A limited number of observations showed that the total is around 50-75 MiB when installed memory is 2 GiB. As a reasonable middle ground, I have preliminarily set the credit to 96 MiB, in case additional kernel features are in use which might add to this total. That said, one common kernel feature which reserves a lot of memory is the `crashkernel` feature.  A `crashkernel=auto` entry on the kernel command line can by itself use over a hundred MiB, and it may be useful for the check to test for this and notify the user that disabling this might be worthwhile.