### PR TITLE
Add problematic alt-rubygem packages to the workaround script

### DIFF
--- a/commands/upgrade/util.py
+++ b/commands/upgrade/util.py
@@ -301,7 +301,7 @@ def format_actor_exceptions(logger):
             msg = "{} - Please check the above details".format(err.message)
             sys.stderr.write("\n")
             sys.stderr.write(pretty_block_text(msg, color="", width=len(msg)))
-            logger.error(e.message)
+            logger.error(err.message)
     finally:
         pass
 

--- a/repos/system_upgrade/cloudlinux/actors/registerpackageworkarounds/libraries/registerpackageworkarounds.py
+++ b/repos/system_upgrade/cloudlinux/actors/registerpackageworkarounds/libraries/registerpackageworkarounds.py
@@ -4,9 +4,14 @@ from leapp.libraries.stdlib import api
 
 # NOTE: The related packages are listed both here *and* in the workaround script!
 # If the list changes, it has to change in both places.
+# Script location: repos\system_upgrade\cloudlinux\tools\remove-problem-packages
 # This is a limitation of the current DNFWorkaround implementation.
 # TODO: unify the list in one place. A separate common file, perhaps?
-TO_REINSTALL = ['gettext-devel']  # These packages will be marked for installation
+TO_REINSTALL = [
+    "gettext-devel",
+    "alt-ruby31-rubygem-rack",
+    "alt-ruby31-rubygem-rackup",
+]  # These packages will be marked for installation
 TO_DELETE = []  # These won't be
 
 
@@ -17,9 +22,11 @@ def produce_workaround_msg(pkg_list, reinstall):
     # Only produce a message if a package is actually about to be uninstalled
     for rpm_pkgs in api.consume(InstalledRPM):
         for pkg in rpm_pkgs.items:
-            if (pkg.name in pkg_list):
+            if pkg.name in pkg_list:
                 preremoved_pkgs.items.append(pkg)
-                api.current_logger().debug("Listing package {} to be pre-removed".format(pkg.name))
+                api.current_logger().debug(
+                    "Listing package {} to be pre-removed".format(pkg.name)
+                )
     if preremoved_pkgs.items:
         api.produce(preremoved_pkgs)
 
@@ -32,7 +39,7 @@ def process():
         # yum doesn't consider attempting to remove a non-existent package to be an error
         # we can safely give it the entire package list without checking if all are installed
         DNFWorkaround(
-            display_name='problem package modification',
-            script_path=api.get_tool_path('remove-problem-packages'),
+            display_name="problem package modification",
+            script_path=api.get_tool_path("remove-problem-packages"),
         )
     )

--- a/repos/system_upgrade/cloudlinux/tools/remove-problem-packages
+++ b/repos/system_upgrade/cloudlinux/tools/remove-problem-packages
@@ -2,3 +2,5 @@
 
 # can't be removed in the main transaction due to errors in %preun
 yum -y --setopt=tsflags=noscripts remove gettext-devel
+# can be removed normally
+yum -y remove alt-ruby31-rubygem-rack alt-ruby31-rubygem-rackup


### PR DESCRIPTION
Current versions of alt-ruby31-rubygem-rack and alt-ruby31-rubygem-rackup cannot properly upgrade from CL7 versions to CL8, causing a file conflict and blocking the DNF transaction from resolving correctly.
The packages themselves will be fixed at a later time, while this delete-reinstall workaround will prevent issues from occurring in the meantime.