### PR TITLE
Add preliminary repository for Microsoft software

### DIFF
--- a/repos/system_upgrade/microsoft/.leapp/info
+++ b/repos/system_upgrade/microsoft/.leapp/info
@@ -1,0 +1,1 @@
+{"name": "microsoft", "id": "56afecad-ebfe-4262-adba-8856a67babdf", "repos": ["644900a5-c347-43a3-bfab-f448f46d9647"]}

--- a/repos/system_upgrade/microsoft/.leapp/leapp.conf
+++ b/repos/system_upgrade/microsoft/.leapp/leapp.conf
@@ -1,0 +1,6 @@
+
+[repositories]
+repo_path=${repository:root_dir}
+
+[database]
+path=${repository:state_dir}/leapp.db

--- a/repos/system_upgrade/microsoft/actors/cleanmanualrepofile/actor.py
+++ b/repos/system_upgrade/microsoft/actors/cleanmanualrepofile/actor.py
@@ -1,0 +1,45 @@
+import os
+
+from leapp.actors import Actor
+from leapp.libraries.stdlib import api
+from leapp.models import ActiveVendorList, RepositoriesFacts
+from leapp.tags import IPUWorkflowTag, FirstBootPhaseTag
+
+VENDOR_NAME = 'microsoft'
+REPO_NAME = 'packages-microsoft-com-prod'
+REPO_FILE_NAME = '/etc/yum.repos.d/microsoft-prod.repo'
+
+class CleanManualRepoFile(Actor):
+    """
+    If there is a repo file associated with the vendor which does not belong to
+    a package, rename that repo file to disable it.
+    """
+
+    name = 'clean_manual_repo_file'
+    consumes = (ActiveVendorList, RepositoriesFacts)
+    produces = ()
+    tags = (IPUWorkflowTag, FirstBootPhaseTag)
+
+    def process(self):
+        active_vendors = []
+        for vendor_list in api.consume(ActiveVendorList):
+            active_vendors.extend(vendor_list.data)
+
+        if VENDOR_NAME in active_vendors:
+
+            for repos in api.consume(RepositoriesFacts):
+                for repo_file in repos.repositories:
+                    if repo_file.file != REPO_FILE_NAME:
+                        self._process_repo_file(repo_file)
+
+    def _process_repo_file(self, repo_file):
+        for repo in repo_file.data:
+            if repo.repoid == REPO_NAME and repo.enabled:
+                self._disable_repo_file(repo_file.file)
+
+    def _disable_repo_file(self, file_path):
+        api.current_logger().info('Renaming {} to disable the unmanaged {} file.')
+        try:
+            os.rename(file_path, file_path + '.disabled')
+        except OSError as e:
+            api.current_logger().warn('Could not rename {} to {}: {}'.format(e.filename, e.filename2, e.strerror))

--- a/repos/system_upgrade/microsoft/actors/detectmanualrepofile/actor.py
+++ b/repos/system_upgrade/microsoft/actors/detectmanualrepofile/actor.py
@@ -1,0 +1,41 @@
+from leapp.actors import Actor
+from leapp.libraries.stdlib import api
+from leapp.models import RpmTransactionTasks, InstalledRPM, ActiveVendorList
+from leapp.tags import IPUWorkflowTag, FactsPhaseTag
+from leapp.libraries.common.rpms import has_package
+
+VENDOR_NAME = 'microsoft'
+REPO_PKG_NAME = 'packages-microsoft-prod'
+
+class DetectManualRepoFile(Actor):
+    """
+    If the vendor is active, but the repo file used for this process isn't the
+    one owned by a package in the repo itself, install that package at the
+    appropriate time.
+    """
+
+    name = 'detect_manual_repo_file'
+    consumes = (ActiveVendorList, InstalledRPM)
+    produces = (RpmTransactionTasks,)
+    tags = (IPUWorkflowTag, FactsPhaseTag)
+
+    def process(self):
+
+        active_vendors = []
+        for vendor_list in api.consume(ActiveVendorList):
+            active_vendors.extend(vendor_list.data)
+
+        if VENDOR_NAME in active_vendors:
+            api.current_logger().info('Vendor {} is active. Looking for information...'.format(VENDOR_NAME))
+
+            if has_package(InstalledRPM, REPO_PKG_NAME):
+                api.current_logger().info(
+                    'Package {} is installed: vendor will upgrade this to point DNF to the correct repo.'.format(
+                        REPO_PKG_NAME
+                    )
+                )
+            else:
+                api.current_logger().info(
+                    'Package {} is not installed: requesting installation.'.format(REPO_PKG_NAME)
+                )
+                api.produce(RpmTransactionTasks(to_install=[REPO_PKG_NAME,]))


### PR DESCRIPTION
Microsoft publishes an RPM in their repos which provides a canonical YUM repo file; however, it seems to be common practice not to use this package-owned file. This makes the upgrade more trouble than it should be. Instead, make sure that the package is installed during the update, and then rename the old manual repo file to disable it on first boot into the new OS.

The actors all depend on the accompanying PES vendor in order to do anything. See Almalinux/leapp-data#30 for that commit.