### PR TITLE
Add EuroLinux to the list of distributions, where grub config should …

### DIFF
--- a/repos/system_upgrade/common/actors/efibootorderfix/finalization/actor.py
+++ b/repos/system_upgrade/common/actors/efibootorderfix/finalization/actor.py
@@ -32,6 +32,7 @@ class EfiFinalizationFix(Actor):
                 'Red Hat Enterprise Linux': 'redhat',
                 'Rocky Linux': 'rocky',
                 'Scientific Linux': 'redhat',
+                'EuroLinux': 'eurolinux',
         }
 
         efi_shimname_dict = {


### PR DESCRIPTION
…be created in case if EFI.