### PR TITLE
Update actor.py to support NVMe device enumeration

### DIFF
--- a/repos/system_upgrade/common/actors/efibootorderfix/finalization/actor.py
+++ b/repos/system_upgrade/common/actors/efibootorderfix/finalization/actor.py
@@ -42,8 +42,24 @@ class EfiFinalizationFix(Actor):
         }
 
         def devparts(dev):
-          part = next(re.finditer(r'\d+$', dev)).group(0)
-          dev = dev[:-len(part)]
+          """
+          NVMe block devices aren't named like SCSI/ATA/etc block devices and must be parsed differently.
+          SCSI/ATA/etc devices have a syntax resembling /dev/sdb4 for the 4th partition on the 2nd disk.
+          NVMe devices have a syntax resembling /dev/nvme0n2p4 for the 4th partition on the 2nd disk.
+          """
+          if '/dev/nvme' in dev:
+            """
+            NVMe
+            """
+            part = next(re.finditer(r'p\d+$', dev)).group(0)
+            dev = dev[:-len(part)]
+            part = part[1:]
+          else:
+            """
+            Non-NVMe (SCSI, ATA, etc)
+            """
+            part = next(re.finditer(r'\d+$', dev)).group(0)
+            dev = dev[:-len(part)]
           return [dev, part];
 
         with open('/etc/system-release', 'r') as sr:


### PR DESCRIPTION
When attempting to upgrade CentOS 7 systems with UEFI and software RAID1 on top of NVMe disks, the upgrade fails during Finalization with the following:

`leapp.libraries.stdlib.CalledProcessError: Command ['/sbin/efibootmgr', '-c', '-d', '/dev/nvme0n1p', '-p', '3', '-l', '\\EFI\rocky\\shimx64.efi', '-L', 'Rocky Linux'] failed with exit code 5`

The failure is due to `efidev` being parsed into `/dev/nvme0n1p` instead of `/dev/nvme0n1`.  _(NVMe device enumeration follows a different format than most typical non-NVMe block devices.)_

This was confirmed with `leapp-upgrade-el7toel8-0.16.0-6.el7.elevate.19.noarch` / `leapp-upgrade-el7toel8-deps-0.16.0-6.el7.elevate.19.noarch`.

This PR modifies `devparts` to check if the argument contains '/dev/nvme' and, if so, generated `dev` and `part` slightly differently.

Before this PR, `/usr/share/leapp-repository/repositories/system_upgrade/common/actors/efibootorderfix/finalization/actor.py` attempts to execute:
`/sbin/efibootmgr -c -d /dev/nvme0n1p -p 3 -l \\EFI\rocky\\shimx64.efi -L 'Rocky Linux'`
and
`/sbin/efibootmgr -c -d /dev/nvme0n2p -p 3 -l \\EFI\rocky\\shimx64.efi -L 'Rocky Linux'`
which have misnamed devices. The failure is triggered when the first command is reached.

After this PR, the device names are correct and the actor attempts to execute:
`/sbin/efibootmgr -c -d /dev/nvme0n1 -p 3 -l \\EFI\rocky\\shimx64.efi -L 'Rocky Linux'`
and
`/sbin/efibootmgr -c -d /dev/nvme0n2 -p 3 -l \\EFI\rocky\\shimx64.efi -L 'Rocky Linux'`.