### PR TITLE
Fix dot-less CentOS Stream release determining.

### DIFF
--- a/repos/system_upgrade/common/actors/ipuworkflowconfig/libraries/ipuworkflowconfig.py
+++ b/repos/system_upgrade/common/actors/ipuworkflowconfig/libraries/ipuworkflowconfig.py
@@ -53,7 +53,7 @@ def get_os_release(path):
             data = dict(l.strip().split('=', 1) for l in f.readlines() if '=' in l)
             release_id = data.get('ID', '').strip('"')
             version_id = data.get('VERSION_ID', '').strip('"')
-            if release_id == 'centos' and '.' not in version_id:
+            if release_id == 'centos' and '.' not in os_version:
                 os_version = "{}.999".format(version_id)
             return OSRelease(
                 release_id=release_id,


### PR DESCRIPTION
This fixes PR #107.

The `version_id` doesn't include OS full version (with '.' included). But the only its major number.
The `os_version` does.