### PR TITLE
Ignore VSCode workspace files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -111,6 +111,7 @@ ENV/
 
 # visual studio code configuration
 .vscode
+*.code-workspace
 
 # pycharm
 .idea


### PR DESCRIPTION
In addition to the already present `.vscode` ignore.