### PR TITLE
Fix ELS kernels detection and add TuxCare and ELevate keys

### DIFF
--- a/repos/system_upgrade/common/actors/kernel/checkinstalledkernels/libraries/checkinstalledkernels.py
+++ b/repos/system_upgrade/common/actors/kernel/checkinstalledkernels/libraries/checkinstalledkernels.py
@@ -29,7 +29,7 @@ def get_current_kernel_release():
     """
     Get the release of the current kernel as a string.
     """
-    return api.current_actor().configuration.kernel.split('-')[1]
+    return api.current_actor().configuration.kernel.split('-')[1].rsplit('.', 1)[0]
 
 
 def get_current_kernel_evr():
@@ -78,7 +78,7 @@ def get_newest_evr(pkgs):
     """
     if not pkgs:
         return None
-    rpms_evr = _get_pkgs_evr(pkgs)
+    rpms_evr = [ ('', pkg.version, pkg.release) for pkg in pkgs ]
 
     newest_evr = rpms_evr.pop()
     for pkg in rpms_evr:

--- a/repos/system_upgrade/common/actors/redhatsignedrpmscanner/actor.py
+++ b/repos/system_upgrade/common/actors/redhatsignedrpmscanner/actor.py
@@ -15,10 +15,12 @@ VENDOR_SIGS = {
                '4eb84e71f2ee9d55',
                'a963bbdbf533f4fa',
                '6c7cb6ef305d49d6'],
-    'cloudlinux': ['8c55a6628608cb71'],
+    'cloudlinux': ['8c55a6628608cb71',
+                   'd07bf2a08d50eb66'], # TuxCare
     'almalinux': ['51d6647ec21ad6ea',
                   'd36cb86cb86b3716',
-                  '2ae81e8aced7258b'],
+                  '2ae81e8aced7258b',
+                  '429785e181b961a5'], # ELevate
     'rocky': ['15af5dac6d745a60',
               '702d426d350d275d'],
     'ol': ['72f97b74ec551f03',


### PR DESCRIPTION
EVR of kernel packages in Leapp 0.16.0 is not correct as Release contains Arch as well.
This makes incorrect comparison of kernel versions:
3.10.0-1160.119.1.el7.x86_64 > 3.10.0-1160.119.1.el7.tuxcare.els1.x86_64

This PR fixes this as well as adds TuxCare key fingerprint (used to sign ELS packages) and ELevate key fingerprint as well.