### PR TITLE
Add one of PostgreSQL's keys to the list of obsoleted ones for 9

### DIFF
--- a/repos/system_upgrade/common/actors/removeobsoletegpgkeys/libraries/removeobsoleterpmgpgkeys.py
+++ b/repos/system_upgrade/common/actors/removeobsoletegpgkeys/libraries/removeobsoleterpmgpgkeys.py
@@ -15,6 +15,7 @@ OBSOLETED_KEYS_MAP = {
         "gpg-pubkey-d4082792-5b32db75",
         "gpg-pubkey-3abb34f8-5ffd890e",
         "gpg-pubkey-6275f250-5e26cb2e",
+        "gpg-pubkey-73e3b907-6581b071", # PostgreSQL RPM Repository <pgsql-pkg-yum@lists.postgresql.org>
     ],
 }
 


### PR DESCRIPTION
The key is: gpg-pubkey-73e3b907-6581b071	gpg(PostgreSQL RPM Repository <pgsql-pkg-yum@lists.postgresql.org>)