### PR TITLE
Drop almalinux from repository mappings.

### DIFF
--- a/etc/leapp/files/repomap.json
+++ b/etc/leapp/files/repomap.json
@@ -308,38 +308,6 @@
                     "arch": "aarch64",
                     "channel": "ga",
                     "repo_type": "rpm",
-                    "distro": "almalinux"
-                },
-                {
-                    "major_version": "10",
-                    "repoid": "baseos",
-                    "arch": "ppc64le",
-                    "channel": "ga",
-                    "repo_type": "rpm",
-                    "distro": "almalinux"
-                },
-                {
-                    "major_version": "10",
-                    "repoid": "baseos",
-                    "arch": "s390x",
-                    "channel": "ga",
-                    "repo_type": "rpm",
-                    "distro": "almalinux"
-                },
-                {
-                    "major_version": "10",
-                    "repoid": "baseos",
-                    "arch": "x86_64",
-                    "channel": "ga",
-                    "repo_type": "rpm",
-                    "distro": "almalinux"
-                },
-                {
-                    "major_version": "10",
-                    "repoid": "baseos",
-                    "arch": "aarch64",
-                    "channel": "ga",
-                    "repo_type": "rpm",
                     "distro": "centos"
                 },
                 {
@@ -517,38 +485,6 @@
         {
             "pesid": "rhel10-AppStream",
             "entries": [
-                {
-                    "major_version": "10",
-                    "repoid": "appstream",
-                    "arch": "aarch64",
-                    "channel": "ga",
-                    "repo_type": "rpm",
-                    "distro": "almalinux"
-                },
-                {
-                    "major_version": "10",
-                    "repoid": "appstream",
-                    "arch": "ppc64le",
-                    "channel": "ga",
-                    "repo_type": "rpm",
-                    "distro": "almalinux"
-                },
-                {
-                    "major_version": "10",
-                    "repoid": "appstream",
-                    "arch": "s390x",
-                    "channel": "ga",
-                    "repo_type": "rpm",
-                    "distro": "almalinux"
-                },
-                {
-                    "major_version": "10",
-                    "repoid": "appstream",
-                    "arch": "x86_64",
-                    "channel": "ga",
-                    "repo_type": "rpm",
-                    "distro": "almalinux"
-                },
                 {
                     "major_version": "10",
                     "repoid": "appstream",
@@ -877,38 +813,6 @@
                     "channel": "ga",
                     "repo_type": "rpm",
                     "distro": "centos"
-                },
-                {
-                    "major_version": "10",
-                    "repoid": "crb",
-                    "arch": "aarch64",
-                    "channel": "ga",
-                    "repo_type": "rpm",
-                    "distro": "almalinux"
-                },
-                {
-                    "major_version": "10",
-                    "repoid": "crb",
-                    "arch": "ppc64le",
-                    "channel": "ga",
-                    "repo_type": "rpm",
-                    "distro": "almalinux"
-                },
-                {
-                    "major_version": "10",
-                    "repoid": "crb",
-                    "arch": "s390x",
-                    "channel": "ga",
-                    "repo_type": "rpm",
-                    "distro": "almalinux"
-                },
-                {
-                    "major_version": "10",
-                    "repoid": "crb",
-                    "arch": "x86_64",
-                    "channel": "ga",
-                    "repo_type": "rpm",
-                    "distro": "almalinux"
                 }
             ]
         },
@@ -1080,28 +984,12 @@
                     "channel": "ga",
                     "repo_type": "rpm",
                     "distro": "centos"
-                },
-                {
-                    "major_version": "10",
-                    "repoid": "rt",
-                    "arch": "x86_64",
-                    "channel": "ga",
-                    "repo_type": "rpm",
-                    "distro": "almalinux"
                 }
             ]
         },
         {
             "pesid": "rhel10-NFV",
             "entries": [
-                {
-                    "major_version": "10",
-                    "repoid": "nfv",
-                    "arch": "x86_64",
-                    "channel": "ga",
-                    "repo_type": "rpm",
-                    "distro": "almalinux"
-                },
                 {
                     "major_version": "10",
                     "repoid": "nfv",
@@ -1293,38 +1181,6 @@
         {
             "pesid": "rhel10-HighAvailability",
             "entries": [
-                {
-                    "major_version": "10",
-                    "repoid": "highavailability",
-                    "arch": "aarch64",
-                    "channel": "ga",
-                    "repo_type": "rpm",
-                    "distro": "almalinux"
-                },
-                {
-                    "major_version": "10",
-                    "repoid": "highavailability",
-                    "arch": "ppc64le",
-                    "channel": "ga",
-                    "repo_type": "rpm",
-                    "distro": "almalinux"
-                },
-                {
-                    "major_version": "10",
-                    "repoid": "highavailability",
-                    "arch": "s390x",
-                    "channel": "ga",
-                    "repo_type": "rpm",
-                    "distro": "almalinux"
-                },
-                {
-                    "major_version": "10",
-                    "repoid": "highavailability",
-                    "arch": "x86_64",
-                    "channel": "ga",
-                    "repo_type": "rpm",
-                    "distro": "almalinux"
-                },
                 {
                     "major_version": "10",
                     "repoid": "highavailability",
@@ -4406,38 +4262,6 @@
                     "arch": "aarch64",
                     "channel": "ga",
                     "repo_type": "rpm",
-                    "distro": "almalinux"
-                },
-                {
-                    "major_version": "9",
-                    "repoid": "baseos",
-                    "arch": "ppc64le",
-                    "channel": "ga",
-                    "repo_type": "rpm",
-                    "distro": "almalinux"
-                },
-                {
-                    "major_version": "9",
-                    "repoid": "baseos",
-                    "arch": "s390x",
-                    "channel": "ga",
-                    "repo_type": "rpm",
-                    "distro": "almalinux"
-                },
-                {
-                    "major_version": "9",
-                    "repoid": "baseos",
-                    "arch": "x86_64",
-                    "channel": "ga",
-                    "repo_type": "rpm",
-                    "distro": "almalinux"
-                },
-                {
-                    "major_version": "9",
-                    "repoid": "baseos",
-                    "arch": "aarch64",
-                    "channel": "ga",
-                    "repo_type": "rpm",
                     "distro": "centos"
                 },
                 {
@@ -4713,38 +4537,6 @@
         {
             "pesid": "rhel9-AppStream",
             "entries": [
-                {
-                    "major_version": "9",
-                    "repoid": "appstream",
-                    "arch": "aarch64",
-                    "channel": "ga",
-                    "repo_type": "rpm",
-                    "distro": "almalinux"
-                },
-                {
-                    "major_version": "9",
-                    "repoid": "appstream",
-                    "arch": "ppc64le",
-                    "channel": "ga",
-                    "repo_type": "rpm",
-                    "distro": "almalinux"
-                },
-                {
-                    "major_version": "9",
-                    "repoid": "appstream",
-                    "arch": "s390x",
-                    "channel": "ga",
-                    "repo_type": "rpm",
-                    "distro": "almalinux"
-                },
-                {
-                    "major_version": "9",
-                    "repoid": "appstream",
-                    "arch": "x86_64",
-                    "channel": "ga",
-                    "repo_type": "rpm",
-                    "distro": "almalinux"
-                },
                 {
                     "major_version": "9",
                     "repoid": "appstream",
@@ -5183,38 +4975,6 @@
                 },
                 {
                     "major_version": "9",
-                    "repoid": "crb",
-                    "arch": "aarch64",
-                    "channel": "ga",
-                    "repo_type": "rpm",
-                    "distro": "almalinux"
-                },
-                {
-                    "major_version": "9",
-                    "repoid": "crb",
-                    "arch": "ppc64le",
-                    "channel": "ga",
-                    "repo_type": "rpm",
-                    "distro": "almalinux"
-                },
-                {
-                    "major_version": "9",
-                    "repoid": "crb",
-                    "arch": "s390x",
-                    "channel": "ga",
-                    "repo_type": "rpm",
-                    "distro": "almalinux"
-                },
-                {
-                    "major_version": "9",
-                    "repoid": "crb",
-                    "arch": "x86_64",
-                    "channel": "ga",
-                    "repo_type": "rpm",
-                    "distro": "almalinux"
-                },
-                {
-                    "major_version": "9",
                     "repoid": "rhui-codeready-builder-for-rhel-9-aarch64-rhui-rpms",
                     "arch": "aarch64",
                     "channel": "ga",
@@ -5446,28 +5206,12 @@
                     "channel": "ga",
                     "repo_type": "rpm",
                     "distro": "centos"
-                },
-                {
-                    "major_version": "9",
-                    "repoid": "rt",
-                    "arch": "x86_64",
-                    "channel": "ga",
-                    "repo_type": "rpm",
-                    "distro": "almalinux"
                 }
             ]
         },
         {
             "pesid": "rhel9-NFV",
             "entries": [
-                {
-                    "major_version": "9",
-                    "repoid": "nfv",
-                    "arch": "x86_64",
-                    "channel": "ga",
-                    "repo_type": "rpm",
-                    "distro": "almalinux"
-                },
                 {
                     "major_version": "9",
                     "repoid": "nfv",
@@ -5722,38 +5466,6 @@
         {
             "pesid": "rhel9-HighAvailability",
             "entries": [
-                {
-                    "major_version": "9",
-                    "repoid": "highavailability",
-                    "arch": "aarch64",
-                    "channel": "ga",
-                    "repo_type": "rpm",
-                    "distro": "almalinux"
-                },
-                {
-                    "major_version": "9",
-                    "repoid": "highavailability",
-                    "arch": "ppc64le",
-                    "channel": "ga",
-                    "repo_type": "rpm",
-                    "distro": "almalinux"
-                },
-                {
-                    "major_version": "9",
-                    "repoid": "highavailability",
-                    "arch": "s390x",
-                    "channel": "ga",
-                    "repo_type": "rpm",
-                    "distro": "almalinux"
-                },
-                {
-                    "major_version": "9",
-                    "repoid": "highavailability",
-                    "arch": "x86_64",
-                    "channel": "ga",
-                    "repo_type": "rpm",
-                    "distro": "almalinux"
-                },
                 {
                     "major_version": "9",
                     "repoid": "highavailability",


### PR DESCRIPTION
Upstream uses an internal generator for the `etc/leapp/files/repomap.json. Any manual changes will be dropped. To cover changes in the repomapping, the generator needs to be updated first.