### PR TITLE
checkmicroarchitecture: allow AlmaLinux 10 x86-64-v2 targets

### DIFF
--- a/repos/system_upgrade/common/actors/checkmicroarchitecture/actor.py
+++ b/repos/system_upgrade/common/actors/checkmicroarchitecture/actor.py
@@ -20,6 +20,10 @@ class CheckMicroarchitecture(Actor):
     CPU compatible with ``x86-64-v2`` instruction set or higher. Similarly,
     RHEL10 requires at least ``x86-64-v3`` instruction set.
 
+    AlmaLinux 10 is additionally built for the ``x86-64-v2`` microarchitecture
+    level, so when the upgrade target distro is AlmaLinux the requirement for
+    the target major version 10 is kept at ``x86-64-v2``.
+
     .. table:: Required CPU features by microarchitecure level with a
                corresponding flag as shown by ``lscpu``.
 

--- a/repos/system_upgrade/common/actors/checkmicroarchitecture/libraries/checkmicroarchitecture.py
+++ b/repos/system_upgrade/common/actors/checkmicroarchitecture/libraries/checkmicroarchitecture.py
@@ -1,6 +1,7 @@
 from collections import namedtuple
 
 from leapp import reporting
+from leapp.libraries.common.config import get_target_distro_id
 from leapp.libraries.common.config.architecture import ARCH_X86_64, matches_architecture
 from leapp.libraries.common.config.version import get_target_major_version
 from leapp.libraries.common.distro import DISTRO_REPORT_NAMES
@@ -60,16 +61,30 @@ def process():
         url='https://red.ht/rhel-10-intel-microarchitectures'
     )
 
-    rhel_major_to_microarch_reqs = {
-        '9': MicroarchInfo(microarch_ver='x86-64-v2',
-                           required_flags=(X86_64_BASELINE_FLAGS + X86_64_V2_FLAGS),
-                           extra_report_fields=[rhel9_microarch_article]),
-        '10': MicroarchInfo(microarch_ver='x86-64-v3',
-                            required_flags=(X86_64_BASELINE_FLAGS + X86_64_V2_FLAGS + X86_64_V3_FLAGS),
-                            extra_report_fields=[rhel10_microarch_article]),
-    }
+    # AlmaLinux 10 is additionally built for the x86-64-v2 microarchitecture
+    # level, so the baseline requirement for AlmaLinux targets stays at v2
+    # regardless of the major version. For RHEL/CentOS Stream 10 the
+    # requirement is x86-64-v3 (RHEL 10 dropped support for v2).
+    if get_target_distro_id() == 'almalinux':
+        major_to_microarch_reqs = {
+            '9': MicroarchInfo(microarch_ver='x86-64-v2',
+                               required_flags=(X86_64_BASELINE_FLAGS + X86_64_V2_FLAGS),
+                               extra_report_fields=[rhel9_microarch_article]),
+            '10': MicroarchInfo(microarch_ver='x86-64-v2',
+                                required_flags=(X86_64_BASELINE_FLAGS + X86_64_V2_FLAGS),
+                                extra_report_fields=[]),
+        }
+    else:
+        major_to_microarch_reqs = {
+            '9': MicroarchInfo(microarch_ver='x86-64-v2',
+                               required_flags=(X86_64_BASELINE_FLAGS + X86_64_V2_FLAGS),
+                               extra_report_fields=[rhel9_microarch_article]),
+            '10': MicroarchInfo(microarch_ver='x86-64-v3',
+                                required_flags=(X86_64_BASELINE_FLAGS + X86_64_V2_FLAGS + X86_64_V3_FLAGS),
+                                extra_report_fields=[rhel10_microarch_article]),
+        }
 
-    microarch_info = rhel_major_to_microarch_reqs.get(get_target_major_version())
+    microarch_info = major_to_microarch_reqs.get(get_target_major_version())
     if not microarch_info:
         api.current_logger().info(
             'No known microarchitecture requirements are known'

--- a/repos/system_upgrade/common/actors/checkmicroarchitecture/tests/test_checkmicroarchitecture.py
+++ b/repos/system_upgrade/common/actors/checkmicroarchitecture/tests/test_checkmicroarchitecture.py
@@ -30,13 +30,17 @@ ENTIRE_V3_FLAG_SET = ENTIRE_V2_FLAG_SET + checkmicroarchitecture.X86_64_V3_FLAGS
 
 
 @pytest.mark.parametrize(
-    ('target_ver', 'cpu_flags'),
+    ('target_ver', 'cpu_flags', 'dst_distro'),
     [
-        ('9.0', ENTIRE_V2_FLAG_SET),
-        ('10.0', ENTIRE_V3_FLAG_SET)
+        ('9.0', ENTIRE_V2_FLAG_SET, 'rhel'),
+        ('10.0', ENTIRE_V3_FLAG_SET, 'rhel'),
+        ('9.0', ENTIRE_V2_FLAG_SET, 'almalinux'),
+        # AlmaLinux 10 is built for x86-64-v2 as well, so v2 flags are enough
+        ('10.0', ENTIRE_V2_FLAG_SET, 'almalinux'),
+        ('10.0', ENTIRE_V3_FLAG_SET, 'almalinux'),
     ]
 )
-def test_valid_microarchitecture(monkeypatch, target_ver, cpu_flags):
+def test_valid_microarchitecture(monkeypatch, target_ver, cpu_flags, dst_distro):
     """
     Test no report is generated on a valid microarchitecture
     """
@@ -45,6 +49,7 @@ def test_valid_microarchitecture(monkeypatch, target_ver, cpu_flags):
     monkeypatch.setattr(api, 'current_logger', logger_mocked())
 
     monkeypatch.setattr(api, 'current_actor', CurrentActorMocked(arch=ARCH_X86_64, dst_ver=target_ver,
+                                                                 dst_distro=dst_distro,
                                                                  msgs=[CPUInfo(flags=cpu_flags)]))
 
     checkmicroarchitecture.process()
@@ -54,13 +59,16 @@ def test_valid_microarchitecture(monkeypatch, target_ver, cpu_flags):
 
 
 @pytest.mark.parametrize(
-    ('target_ver', 'cpu_flags'),
+    ('target_ver', 'cpu_flags', 'dst_distro'),
     (
-        ('9.0', checkmicroarchitecture.X86_64_BASELINE_FLAGS),
-        ('10.0', ENTIRE_V2_FLAG_SET),
+        ('9.0', checkmicroarchitecture.X86_64_BASELINE_FLAGS, 'rhel'),
+        ('10.0', ENTIRE_V2_FLAG_SET, 'rhel'),
+        ('9.0', checkmicroarchitecture.X86_64_BASELINE_FLAGS, 'almalinux'),
+        # AlmaLinux 10 still requires v2 as the baseline
+        ('10.0', checkmicroarchitecture.X86_64_BASELINE_FLAGS, 'almalinux'),
     )
 )
-def test_invalid_microarchitecture(monkeypatch, target_ver, cpu_flags):
+def test_invalid_microarchitecture(monkeypatch, target_ver, cpu_flags, dst_distro):
     """
     Test report is generated on x86-64 architecture with invalid microarchitecture and the upgrade is inhibited
     """
@@ -68,7 +76,8 @@ def test_invalid_microarchitecture(monkeypatch, target_ver, cpu_flags):
     monkeypatch.setattr(reporting, "create_report", create_report_mocked())
     monkeypatch.setattr(api, 'current_logger', logger_mocked())
     monkeypatch.setattr(api, 'current_actor',
-                        CurrentActorMocked(arch=ARCH_X86_64, msgs=[cpu_info], dst_ver=target_ver))
+                        CurrentActorMocked(arch=ARCH_X86_64, msgs=[cpu_info], dst_ver=target_ver,
+                                           dst_distro=dst_distro))
 
     checkmicroarchitecture.process()
 


### PR DESCRIPTION
AlmaLinux 10 is additionally built for the x86-64-v2 microarchitecture level, so when the upgrade target distro is AlmaLinux the requirement for target major version 10 stays at x86-64-v2 instead of RHEL 10's x86-64-v3. Other target distros (RHEL, CentOS Stream) keep the original x86-64-v3 requirement on 10.